### PR TITLE
Fixed function call when opening database fails

### DIFF
--- a/wasm-utils.js
+++ b/wasm-utils.js
@@ -78,7 +78,7 @@ function instantiateCachedURL(dbVersion, url, importObject) {
     // to simply fetching and compiling the module and don't try to store the
     // results.
     console.log(errMsg);
-    return WebAssembly.instantiateSteaming(fetch(url)).then(results => {
+    return WebAssembly.instantiateStreaming(fetch(url)).then(results => {
       return results.instance
     });
   });


### PR DESCRIPTION
I have fixed the function call "instantiateSteaming" to instead use the existing function name "instantiateStreaming."