### PR TITLE
Reformat examples, remove `var`, update examples

### DIFF
--- a/js-api-examples/compile-streaming.html
+++ b/js-api-examples/compile-streaming.html
@@ -19,15 +19,18 @@
         }
       };
 
+      // equivalent:
       // fetch("simple.wasm")
       // .then(response => response.arrayBuffer())
       // .then(bytes => WebAssembly.compile(bytes))
       // .then(module => WebAssembly.instantiate(module, importObject))
-      // .then(instance => instance.exports.exported_func());
+      // .then(instance => { instance.exports.exported_func(); });
 
       WebAssembly.compileStreaming(fetch("simple.wasm"))
       .then(module => WebAssembly.instantiate(module, importObject))
-      .then(instance => instance.exports.exported_func());
+      .then(instance => {
+        instance.exports.exported_func();
+      });
     </script>
   </body>
 

--- a/js-api-examples/compile-streaming.html
+++ b/js-api-examples/compile-streaming.html
@@ -11,15 +11,21 @@
 
 
     <script>
-      var importObject = { imports: { imported_func: arg => console.log(arg) } };
+      const importObject = {
+        imports: {
+          imported_func: arg => {
+            console.log(arg);
+          }
+        }
+      };
 
-      // fetch('simple.wasm')
+      // fetch("simple.wasm")
       // .then(response => response.arrayBuffer())
       // .then(bytes => WebAssembly.compile(bytes))
       // .then(module => WebAssembly.instantiate(module, importObject))
       // .then(instance => instance.exports.exported_func());
 
-      WebAssembly.compileStreaming(fetch('simple.wasm'))
+      WebAssembly.compileStreaming(fetch("simple.wasm"))
       .then(module => WebAssembly.instantiate(module, importObject))
       .then(instance => instance.exports.exported_func());
     </script>

--- a/js-api-examples/fail.html
+++ b/js-api-examples/fail.html
@@ -11,7 +11,7 @@
     <script>
       WebAssembly.instantiateStreaming(fetch("fail.wasm"))
       .then(obj => {
-        obj.instance.exports.fail_me()
+        obj.instance.exports.fail_me();
       });
     </script>
   </body>

--- a/js-api-examples/fail.html
+++ b/js-api-examples/fail.html
@@ -9,8 +9,10 @@
 
   <body>
     <script>
-      WebAssembly.instantiateStreaming(fetch('fail.wasm'))
-      .then(obj => obj.instance.exports.fail_me());
+      WebAssembly.instantiateStreaming(fetch("fail.wasm"))
+      .then(obj => {
+        obj.instance.exports.fail_me()
+      });
     </script>
   </body>
 

--- a/js-api-examples/global.html
+++ b/js-api-examples/global.html
@@ -1,32 +1,37 @@
 <!doctype html>
+
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>WebAssembly Globals example</title>
-</head>
-<body>
-<div id='output'></div>
-<script>
-    const output = document.getElementById('output');
+
+  <head>
+    <meta charset="utf-8">
+    <title>WebAssembly Globals example</title>
+  </head>
+  <body>
+  <div id="output"></div>
+  <script>
+    const output = document.getElementById("output");
 
     function assertEq(msg, got, expected) {
-        output.innerHTML += `Testing ${msg}: `;
-        if (got !== expected)
-            output.innerHTML += `FAIL!<br>Got: ${got}<br>Expected: ${expected}<br>`;
-        else
-            output.innerHTML += `SUCCESS! Got: ${got}<br>`;
+      output.innerHTML += `Testing ${msg}: `;
+      if (got !== expected) {
+        output.innerHTML += `FAIL!<br>Got: ${got}<br>Expected: ${expected}<br>`;
+      } else {
+        output.innerHTML += `SUCCESS! Got: ${got}<br>`;
+      }
     }
 
     assertEq("WebAssembly.Global exists", typeof WebAssembly.Global, "function");
 
-    const global = new WebAssembly.Global({value:'i32', mutable:true}, 0);
-    WebAssembly.instantiateStreaming(fetch('global.wasm'), { js: { global } })
-    .then(({instance}) => {
-        assertEq("getting initial value from wasm", instance.exports.getGlobal(), 0);
-        global.value = 42;
-        assertEq("getting JS-updated value from wasm", instance.exports.getGlobal(), 42);
-        instance.exports.incGlobal();
-        assertEq("getting wasm-updated value from JS", global.value, 43);
+    const global = new WebAssembly.Global({ value: "i32", mutable: true }, 0);
+    WebAssembly.instantiateStreaming(fetch("global.wasm"), { js: { global } })
+    .then(({ instance }) => {
+      assertEq("getting initial value from wasm", instance.exports.getGlobal(), 0);
+      global.value = 42;
+      assertEq("getting JS-updated value from wasm", instance.exports.getGlobal(), 42);
+      instance.exports.incGlobal();
+      assertEq("getting wasm-updated value from JS", global.value, 43);
     });
-</script>
-</body>
+  </script>
+  </body>
+
+</html>

--- a/js-api-examples/global.wat
+++ b/js-api-examples/global.wat
@@ -1,8 +1,6 @@
 (module
-   (global $g (import "js" "global") (mut i32))
-   (func (export "getGlobal") (result i32)
-        (global.get $g))
-   (func (export "incGlobal")
-        (global.set $g
-            (i32.add (global.get $g) (i32.const 1))))
-)
+  (global $g (import "js" "global") (mut i32))
+  (func (export "getGlobal") (result i32)
+    (global.get $g))
+  (func (export "incGlobal")
+    (global.set $g (i32.add (global.get $g) (i32.const 1)))))

--- a/js-api-examples/global.wat
+++ b/js-api-examples/global.wat
@@ -1,6 +1,9 @@
 (module
   (global $g (import "js" "global") (mut i32))
   (func (export "getGlobal") (result i32)
-    (global.get $g))
+    (global.get $g)
+  )
   (func (export "incGlobal")
-    (global.set $g (i32.add (global.get $g) (i32.const 1)))))
+    (global.set $g (i32.add (global.get $g) (i32.const 1)))
+  )
+)

--- a/js-api-examples/imports.html
+++ b/js-api-examples/imports.html
@@ -9,9 +9,9 @@
 
   <body>
     <script>
-      WebAssembly.compileStreaming(fetch('simple.wasm'))
-      .then(function(mod) {
-        var imports = WebAssembly.Module.imports(mod);
+      WebAssembly.compileStreaming(fetch("simple.wasm"))
+      .then(module => {
+        const imports = WebAssembly.Module.imports(module);
         console.log(imports[0]);
       });
     </script>

--- a/js-api-examples/index-compile.html
+++ b/js-api-examples/index-compile.html
@@ -13,7 +13,7 @@
 
       WebAssembly.compileStreaming(fetch("simple.wasm"))
       .then(module => {
-        worker.postMessage(module)
+        worker.postMessage(module);
       });
     </script>
   </body>

--- a/js-api-examples/index-compile.html
+++ b/js-api-examples/index-compile.html
@@ -9,12 +9,12 @@
 
   <body>
     <script>
-      var worker = new Worker("wasm_worker.js");
+      const worker = new Worker("wasm_worker.js");
 
-      WebAssembly.compileStreaming(fetch('simple.wasm'))
-      .then(mod =>
-        worker.postMessage(mod)
-      );
+      WebAssembly.compileStreaming(fetch("simple.wasm"))
+      .then(module => {
+        worker.postMessage(module)
+      });
     </script>
   </body>
 

--- a/js-api-examples/index.html
+++ b/js-api-examples/index.html
@@ -11,7 +11,7 @@
     <script>
       const importObject = {
         imports: {
-          imported_func: function(arg) {
+          imported_func: arg => {
             console.log(arg);
           }
         }

--- a/js-api-examples/index.html
+++ b/js-api-examples/index.html
@@ -9,7 +9,7 @@
 
   <body>
     <script>
-      var importObject = {
+      const importObject = {
         imports: {
           imported_func: function(arg) {
             console.log(arg);
@@ -17,13 +17,13 @@
         }
       };
 
-      fetch('simple.wasm').then(response =>
+      fetch("simple.wasm").then(response =>
         response.arrayBuffer()
       ).then(bytes =>
         WebAssembly.instantiate(bytes, importObject)
-      ).then(result =>
-        result.instance.exports.exported_func()
-      );
+      ).then(result => {
+        result.instance.exports.exported_func();
+      });
     </script>
   </body>
 

--- a/js-api-examples/index_concise.html
+++ b/js-api-examples/index_concise.html
@@ -11,10 +11,18 @@
 
 
     <script>
-      var importObject = { imports: { imported_func: arg => console.log(arg) } };
+      const importObject = {
+        imports: {
+          imported_func: arg => {
+            console.log(arg);
+          }
+        }
+      };
 
-      WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
-      .then(obj => obj.instance.exports.exported_func());
+      WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject)
+      .then(obj => {
+        obj.instance.exports.exported_func();
+      });
     </script>
   </body>
 

--- a/js-api-examples/instantiate-streaming.html
+++ b/js-api-examples/instantiate-streaming.html
@@ -8,13 +8,19 @@
   </head>
 
   <body>
-
-
     <script>
-      var importObject = { imports: { imported_func: arg => console.log(arg) } };
+      const importObject = {
+        imports: {
+          imported_func: arg => {
+            console.log(arg);
+          }
+        }
+      };
 
-      WebAssembly.instantiateStreaming(fetch('simple.wasm'), importObject)
-      .then(obj => obj.instance.exports.exported_func());
+      WebAssembly.instantiateStreaming(fetch("simple.wasm"), importObject)
+      .then(obj => {
+        obj.instance.exports.exported_func();
+      });
     </script>
   </body>
 

--- a/js-api-examples/memory.html
+++ b/js-api-examples/memory.html
@@ -9,15 +9,18 @@
 
   <body>
     <script>
-      var memory = new WebAssembly.Memory({initial:10, maximum:100});
+      const memory = new WebAssembly.Memory({
+        initial: 10,
+        maximum: 100
+      });
 
-      WebAssembly.instantiateStreaming(fetch('memory.wasm'), { js: { mem: memory } })
+      WebAssembly.instantiateStreaming(fetch("memory.wasm"), { js: { mem: memory } })
       .then(obj => {
-        var i32 = new Uint32Array(memory.buffer);
-        for (var i = 0; i < 10; i++) {
+        const i32 = new Uint32Array(memory.buffer);
+        for (let i = 0; i < 10; i++) {
           i32[i] = i;
         }
-        var sum = obj.instance.exports.accumulate(0, 10);
+        const sum = obj.instance.exports.accumulate(0, 10);
         console.log(sum);
       });
     </script>

--- a/js-api-examples/memory.wat
+++ b/js-api-examples/memory.wat
@@ -3,14 +3,26 @@
   (func (export "accumulate") (param $ptr i32) (param $len i32) (result i32)
     (local $end i32)
     (local $sum i32)
-    (local.set $end (i32.add (local.get $ptr) (i32.mul (local.get $len) (i32.const 4))))
-    (block $break (loop $top
-      (br_if $break (i32.eq (local.get $ptr) (local.get $end)))
-      (local.set $sum (i32.add (local.get $sum)
-                               (i32.load (local.get $ptr))))
-        (local.set $ptr (i32.add (local.get $ptr) (i32.const 4)))
-        (br $top)
-    ))
-    (local.get $sum)
-  )
-)
+    (local.set $end
+      (i32.add
+        (local.get $ptr)
+        (i32.mul
+          (local.get $len)
+          (i32.const 4))))
+    (block $break
+      (loop $top
+        (br_if $break
+          (i32.eq
+            (local.get $ptr)
+            (local.get $end)))
+        (local.set $sum
+          (i32.add
+            (local.get $sum)
+            (i32.load
+              (local.get $ptr))))
+        (local.set $ptr
+          (i32.add
+            (local.get $ptr)
+            (i32.const 4)))
+        (br $top)))
+    (local.get $sum)))

--- a/js-api-examples/memory.wat
+++ b/js-api-examples/memory.wat
@@ -24,5 +24,9 @@
           (i32.add
             (local.get $ptr)
             (i32.const 4)))
-        (br $top)))
-    (local.get $sum)))
+        (br $top)
+      )
+    )
+    (local.get $sum)
+  )
+)

--- a/js-api-examples/table.html
+++ b/js-api-examples/table.html
@@ -9,13 +9,17 @@
 
   <body>
     <script>
-      var table = new WebAssembly.Table({ element: "anyfunc", initial: 1, maximum: 10 });
+      const table = new WebAssembly.Table({
+        element: "anyfunc",
+        initial: 1,
+        maximum: 10
+      });
       table.grow(1);
-      console.log(table.length);
+      console.log(table.length);  // 2
 
-      WebAssembly.instantiateStreaming(fetch('table.wasm'))
-      .then(function(obj) {
-        var tbl = obj.instance.exports.tbl;
+      WebAssembly.instantiateStreaming(fetch("table.wasm"))
+      .then(obj => {
+        const tbl = obj.instance.exports.tbl;
         console.log(tbl.get(0)());  // 13
         console.log(tbl.get(1)());  // 42
       });

--- a/js-api-examples/table.wat
+++ b/js-api-examples/table.wat
@@ -1,4 +1,5 @@
 (module
   (func $thirteen (result i32) (i32.const 13))
   (func $fourtytwo (result i32) (i32.const 42))
-  (table (export "tbl") anyfunc (elem $thirteen $fourtytwo)))
+  (table (export "tbl") anyfunc (elem $thirteen $fourtytwo))
+)

--- a/js-api-examples/table.wat
+++ b/js-api-examples/table.wat
@@ -1,5 +1,4 @@
 (module
   (func $thirteen (result i32) (i32.const 13))
   (func $fourtytwo (result i32) (i32.const 42))
-  (table (export "tbl") anyfunc (elem $thirteen $fourtytwo))
-)
+  (table (export "tbl") anyfunc (elem $thirteen $fourtytwo)))

--- a/js-api-examples/table2.html
+++ b/js-api-examples/table2.html
@@ -9,19 +9,22 @@
 
   <body>
     <script>
-      var tbl = new WebAssembly.Table({initial:2, element:"anyfunc"});
+      const tbl = new WebAssembly.Table({
+        initial: 2,
+        element: "anyfunc"
+      });
       console.log(tbl.length);
       console.log(tbl.get(0));
       console.log(tbl.get(1));
 
-      var importObject = {
+      const importObject = {
         js: {
-          tbl:tbl
+          tbl: tbl
         }
       };
 
-      WebAssembly.instantiateStreaming(fetch('table2.wasm'), importObject)
-      .then(function(obj) {
+      WebAssembly.instantiateStreaming(fetch("table2.wasm"), importObject)
+      .then(obj => {
         console.log(tbl.length);
         console.log(tbl.get(0)());
         console.log(tbl.get(1)());

--- a/js-api-examples/table2.html
+++ b/js-api-examples/table2.html
@@ -18,9 +18,7 @@
       console.log(tbl.get(1));
 
       const importObject = {
-        js: {
-          tbl: tbl
-        }
+        js: { tbl }
       };
 
       WebAssembly.instantiateStreaming(fetch("table2.wasm"), importObject)

--- a/js-api-examples/table2.wat
+++ b/js-api-examples/table2.wat
@@ -2,4 +2,5 @@
   (import "js" "tbl" (table 2 anyfunc))
   (func $f42 (result i32) i32.const 42)
   (func $f83 (result i32) i32.const 83)
-  (elem (i32.const 0) $f42 $f83))
+  (elem (i32.const 0) $f42 $f83)
+)

--- a/js-api-examples/table2.wat
+++ b/js-api-examples/table2.wat
@@ -1,6 +1,5 @@
 (module
-    (import "js" "tbl" (table 2 anyfunc))
-    (func $f42 (result i32) i32.const 42)
-    (func $f83 (result i32) i32.const 83)
-    (elem (i32.const 0) $f42 $f83)
-)
+  (import "js" "tbl" (table 2 anyfunc))
+  (func $f42 (result i32) i32.const 42)
+  (func $f83 (result i32) i32.const 83)
+  (elem (i32.const 0) $f42 $f83))

--- a/js-api-examples/validate.html
+++ b/js-api-examples/validate.html
@@ -9,11 +9,11 @@
 
   <body>
     <script>
-      fetch('simple.wasm').then(response =>
+      fetch("simple.wasm").then(response =>
         response.arrayBuffer()
-      ).then(function(bytes) {
-        var valid = WebAssembly.validate(bytes);
-        console.log("The given bytes are " + (valid ? "" : "not ") + "a valid wasm module");
+      ).then(bytes => {
+        const isValid = WebAssembly.validate(bytes);
+        console.log("The given bytes are " + (isValid ? "" : "not ") + "a valid wasm module");
       });
     </script>
   </body>

--- a/js-api-examples/wasm_worker.js
+++ b/js-api-examples/wasm_worker.js
@@ -1,19 +1,20 @@
-var importObject = {
+const importObject = {
   imports: {
-    imported_func: function(arg) {
+    imported_func: arg => {
       console.log(arg);
     }
   }
 };
 
-onmessage = function(e) {
-  console.log('module received from main thread');
-  var mod = e.data;
+window.onmessage = function(event) {
+  console.log("module received from main thread");
+  const module = event.data;
 
-  WebAssembly.instantiate(mod, importObject).then(function(instance) {
-    instance.exports.exported_func();
-  });
+  WebAssembly.instantiate(module, importObject)
+    .then(instance => {
+      instance.exports.exported_func();
+    });
 
-  var exports = WebAssembly.Module.exports(mod);
+  const exports = WebAssembly.Module.exports(module);
   console.log(exports[0]);
 };

--- a/js-api-examples/wasm_worker.js
+++ b/js-api-examples/wasm_worker.js
@@ -6,7 +6,7 @@ const importObject = {
   }
 };
 
-window.onmessage = function(event) {
+self.onmessage = function(event) {
   console.log("module received from main thread");
   const module = event.data;
 

--- a/js-api-examples/xhr-wasm.html
+++ b/js-api-examples/xhr-wasm.html
@@ -25,9 +25,9 @@
       request.onload = () => {
         const bytes = request.response;
         WebAssembly.instantiate(bytes, importObject)
-          .then(obj => {
-            obj.instance.exports.exported_func();
-          });
+        .then(obj => {
+          obj.instance.exports.exported_func();
+        });
       };
     </script>
   </body>

--- a/js-api-examples/xhr-wasm.html
+++ b/js-api-examples/xhr-wasm.html
@@ -9,24 +9,25 @@
 
   <body>
     <script>
-      var importObject = {
+      const importObject = {
         imports: {
-          imported_func: function(arg) {
+          imported_func: arg => {
             console.log(arg);
           }
         }
       };
 
-      request = new XMLHttpRequest();
-      request.open('GET', 'simple.wasm');
-      request.responseType = 'arraybuffer';
+      const request = new XMLHttpRequest();
+      request.open("GET", "simple.wasm");
+      request.responseType = "arraybuffer";
       request.send();
 
-      request.onload = function() {
-        var bytes = request.response;
-        WebAssembly.instantiate(bytes, importObject).then(function(obj) {
-          obj.instance.exports.exported_func();
-        });
+      request.onload = () => {
+        const bytes = request.response;
+        WebAssembly.instantiate(bytes, importObject)
+          .then(obj => {
+            obj.instance.exports.exported_func();
+          });
       };
     </script>
   </body>

--- a/other-examples/custom-section.html
+++ b/other-examples/custom-section.html
@@ -8,10 +8,10 @@
 
 <body>
     <script>
-        WebAssembly.compileStreaming(fetch('simple-name-section.wasm'))
-        .then(function(mod) {
-          var nameSections = WebAssembly.Module.customSections(mod, "name");
-          if (nameSections.length != 0) {
+        WebAssembly.compileStreaming(fetch("simple-name-section.wasm"))
+        .then(module => {
+          const nameSections = WebAssembly.Module.customSections(module, "name");
+          if (nameSections.length !== 0) {
             console.log("Module contains a name section");
             console.log(nameSections[0]);
           };

--- a/other-examples/table-set.html
+++ b/other-examples/table-set.html
@@ -9,11 +9,14 @@
 
   <body>
     <script>
-      const otherTable = new WebAssembly.Table({ element: "anyfunc", initial: 2 });
+      const otherTable = new WebAssembly.Table({
+        element: "anyfunc",
+        initial: 2
+      });
 
       WebAssembly.instantiateStreaming(fetch("table.wasm"))
       .then(obj => {
-        const tbl = obj.instance.exports.tbl;
+        const { tbl } = obj.instance.exports;
         console.log(tbl.get(0)());  // 13
         console.log(tbl.get(1)());  // 42
 

--- a/other-examples/table-set.html
+++ b/other-examples/table-set.html
@@ -9,16 +9,16 @@
 
   <body>
     <script>
-      var otherTable = new WebAssembly.Table({ element: "anyfunc", initial: 2 });
+      const otherTable = new WebAssembly.Table({ element: "anyfunc", initial: 2 });
 
-      WebAssembly.instantiateStreaming(fetch('table.wasm'))
+      WebAssembly.instantiateStreaming(fetch("table.wasm"))
       .then(obj => {
-        var tbl = obj.instance.exports.tbl;
+        const tbl = obj.instance.exports.tbl;
         console.log(tbl.get(0)());  // 13
         console.log(tbl.get(1)());  // 42
 
-        otherTable.set(0,tbl.get(0));
-        otherTable.set(1,tbl.get(1));
+        otherTable.set(0, tbl.get(0));
+        otherTable.set(1, tbl.get(1));
 
         console.log(otherTable.get(0)());
         console.log(otherTable.get(1)());

--- a/understanding-text-format/add.html
+++ b/understanding-text-format/add.html
@@ -10,7 +10,7 @@
   <body>
     <script>
 
-    WebAssembly.instantiateStreaming(fetch('add.wasm'))
+    WebAssembly.instantiateStreaming(fetch("add.wasm"))
     .then(obj => {
        console.log(obj.instance.exports.add(1, 2));  // "3"
     });

--- a/understanding-text-format/add.html
+++ b/understanding-text-format/add.html
@@ -9,11 +9,10 @@
 
   <body>
     <script>
-
-    WebAssembly.instantiateStreaming(fetch("add.wasm"))
-    .then(obj => {
-      console.log(obj.instance.exports.add(1, 2));  // "3"
-    });
+      WebAssembly.instantiateStreaming(fetch("add.wasm"))
+      .then(obj => {
+        console.log(obj.instance.exports.add(1, 2));  // "3"
+      });
     </script>
   </body>
 

--- a/understanding-text-format/add.html
+++ b/understanding-text-format/add.html
@@ -12,7 +12,7 @@
 
     WebAssembly.instantiateStreaming(fetch("add.wasm"))
     .then(obj => {
-       console.log(obj.instance.exports.add(1, 2));  // "3"
+      console.log(obj.instance.exports.add(1, 2));  // "3"
     });
     </script>
   </body>

--- a/understanding-text-format/add.wat
+++ b/understanding-text-format/add.wat
@@ -3,5 +3,4 @@
     local.get $lhs
     local.get $rhs
     i32.add)
-  (export "add" (func $add))
-)
+  (export "add" (func $add)))

--- a/understanding-text-format/add.wat
+++ b/understanding-text-format/add.wat
@@ -2,5 +2,7 @@
   (func $add (param $lhs i32) (param $rhs i32) (result i32)
     local.get $lhs
     local.get $rhs
-    i32.add)
-  (export "add" (func $add)))
+    i32.add
+  )
+  (export "add" (func $add))
+)

--- a/understanding-text-format/call.html
+++ b/understanding-text-format/call.html
@@ -11,7 +11,7 @@
     <script>
       WebAssembly.instantiateStreaming(fetch("call.wasm"))
       .then(obj => {
-         console.log(obj.instance.exports.getAnswerPlus1());  // "43"
+        console.log(obj.instance.exports.getAnswerPlus1());  // "43"
       });
     </script>
   </body>

--- a/understanding-text-format/call.html
+++ b/understanding-text-format/call.html
@@ -9,7 +9,7 @@
 
   <body>
     <script>
-      WebAssembly.instantiateStreaming(fetch('call.wasm'))
+      WebAssembly.instantiateStreaming(fetch("call.wasm"))
       .then(obj => {
          console.log(obj.instance.exports.getAnswerPlus1());  // "43"
       });

--- a/understanding-text-format/logger.html
+++ b/understanding-text-format/logger.html
@@ -11,7 +11,7 @@
     <script>
       const importObject = {
         console: {
-          log: function(arg) {
+          log: arg => {
             console.log(arg);
           }
         }

--- a/understanding-text-format/logger.html
+++ b/understanding-text-format/logger.html
@@ -9,7 +9,7 @@
 
   <body>
     <script>
-      var importObject = {
+      const importObject = {
         console: {
           log: function(arg) {
             console.log(arg);
@@ -17,7 +17,7 @@
         }
       };
 
-      WebAssembly.instantiateStreaming(fetch('logger.wasm'), importObject)
+      WebAssembly.instantiateStreaming(fetch("logger.wasm"), importObject)
       .then(obj => {
         obj.instance.exports.logIt();
       });

--- a/understanding-text-format/logger2.html
+++ b/understanding-text-format/logger2.html
@@ -9,15 +9,15 @@
 
   <body>
     <script>
-      var memory = new WebAssembly.Memory({ initial : 1 });
+      const memory = new WebAssembly.Memory({ initial: 1 });
 
       function consoleLogString(offset, length) {
-        var bytes = new Uint8Array(memory.buffer, offset, length);
-        var string = new TextDecoder('utf8').decode(bytes);
+        const bytes = new Uint8Array(memory.buffer, offset, length);
+        const string = new TextDecoder("UTF-8").decode(bytes);
         console.log(string);
       }
 
-      var importObject = {
+      const importObject = {
         console: {
           log: consoleLogString
         },
@@ -26,7 +26,7 @@
         }
       };
 
-      WebAssembly.instantiateStreaming(fetch('logger2.wasm'), importObject)
+      WebAssembly.instantiateStreaming(fetch("logger2.wasm"), importObject)
       .then(obj => {
         obj.instance.exports.writeHi();
       });

--- a/understanding-text-format/shared-address-space.html
+++ b/understanding-text-format/shared-address-space.html
@@ -9,17 +9,17 @@
 
   <body>
     <script>
-    var importObj = {
+    const importObj = {
       js: {
-        memory : new WebAssembly.Memory({ initial: 1 }),
-        table : new WebAssembly.Table({ initial: 1, element: "anyfunc" })
+        memory: new WebAssembly.Memory({ initial: 1 }),
+        table: new WebAssembly.Table({ initial: 1, element: "anyfunc" })
       }
     };
 
     Promise.all([
-      WebAssembly.instantiateStreaming(fetch('shared0.wasm'), importObj),
-      WebAssembly.instantiateStreaming(fetch('shared1.wasm'), importObj)
-    ]).then(function(results) {
+      WebAssembly.instantiateStreaming(fetch("shared0.wasm"), importObj),
+      WebAssembly.instantiateStreaming(fetch("shared1.wasm"), importObj)
+    ]).then(results => {
       console.log(results[1].instance.exports.doIt());  // prints 42
     });
     </script>

--- a/understanding-text-format/shared0.wat
+++ b/understanding-text-format/shared0.wat
@@ -4,4 +4,6 @@
   (elem (i32.const 0) $shared0func)
   (func $shared0func (result i32)
     i32.const 0
-    i32.load))
+    i32.load
+  )
+)

--- a/understanding-text-format/shared0.wat
+++ b/understanding-text-format/shared0.wat
@@ -3,6 +3,5 @@
   (import "js" "table" (table 1 anyfunc))
   (elem (i32.const 0) $shared0func)
   (func $shared0func (result i32)
-   i32.const 0
-   i32.load)
-)
+    i32.const 0
+    i32.load))

--- a/understanding-text-format/shared1.wat
+++ b/understanding-text-format/shared1.wat
@@ -3,8 +3,5 @@
   (import "js" "table" (table 1 anyfunc))
   (type $void_to_i32 (func (result i32)))
   (func (export "doIt") (result i32)
-
-   (i32.store (i32.const 0) (i32.const 42))  ;; store 42 at address 0
-
-   (call_indirect $void_to_i32 (i32.const 0)))
-)
+    (i32.store (i32.const 0) (i32.const 42))  ;; store 42 at address 0
+    (call_indirect $void_to_i32 (i32.const 0))))

--- a/understanding-text-format/shared1.wat
+++ b/understanding-text-format/shared1.wat
@@ -4,4 +4,6 @@
   (type $void_to_i32 (func (result i32)))
   (func (export "doIt") (result i32)
     (i32.store (i32.const 0) (i32.const 42))  ;; store 42 at address 0
-    (call_indirect $void_to_i32 (i32.const 0))))
+    (call_indirect $void_to_i32 (i32.const 0))
+  )
+)

--- a/understanding-text-format/wasm-table.html
+++ b/understanding-text-format/wasm-table.html
@@ -13,7 +13,7 @@
       .then(obj => {
         console.log(obj.instance.exports.callByIndex(0)); // returns 42
         console.log(obj.instance.exports.callByIndex(1)); // returns 13
-        console.log(obj.instance.exports.callByIndex(2)); // returns an error, because there is no index position 2 in the table
+        console.log(obj.instance.exports.callByIndex(2)); // throws an error, because there is no index position 2 in the table
       });
     </script>
   </body>

--- a/understanding-text-format/wasm-table.html
+++ b/understanding-text-format/wasm-table.html
@@ -9,7 +9,7 @@
 
   <body>
     <script>
-      WebAssembly.instantiateStreaming(fetch('wasm-table.wasm'))
+      WebAssembly.instantiateStreaming(fetch("wasm-table.wasm"))
       .then(obj => {
         console.log(obj.instance.exports.callByIndex(0)); // returns 42
         console.log(obj.instance.exports.callByIndex(1)); // returns 13

--- a/understanding-text-format/wasm-table.wat
+++ b/understanding-text-format/wasm-table.wat
@@ -1,11 +1,15 @@
 (module
   (table 2 anyfunc)
   (func $f1 (result i32)
-    i32.const 42)
+    i32.const 42
+  )
   (func $f2 (result i32)
-    i32.const 13)
+    i32.const 13
+  )
   (elem (i32.const 0) $f1 $f2)
   (type $return_i32 (func (result i32)))
   (func (export "callByIndex") (param $i i32) (result i32)
     local.get $i
-    call_indirect (type $return_i32)))
+    call_indirect (type $return_i32)
+  )
+)

--- a/understanding-text-format/wasm-table.wat
+++ b/understanding-text-format/wasm-table.wat
@@ -8,5 +8,4 @@
   (type $return_i32 (func (result i32)))
   (func (export "callByIndex") (param $i i32) (result i32)
     local.get $i
-    call_indirect (type $return_i32))
-)
+    call_indirect (type $return_i32)))


### PR DESCRIPTION
MDN is looking to remove use of `var` from the JavaScript examples across the website; see https://github.com/mdn/content/issues/16614.

The WebAssembly documentation all references code hosted here, so this repository is being updated, then the updated source code will copied into the MDN articles as appropriate.

* Reformats spacing in in `.html`, `.js`, and `.wat` files.
* Adjusts indentation to 2-spaces for consistency across code.
* Changes `.wat` files to not have the trailing parenthesis to not be on it's own line (for consistency with many existing files).
* Removes all use of `var` in exchange for `const` (`let` wasn't needed).
* Adds a few minor comments for clarification.
* Converts (some) "old-style" functions to arrow functions.
* (Inserted a missing HTML end tag)
* Introduced a few more uses of "destructuring assignment" syntax, as I already encountered some usage through the repository.
* Does not touch Sobel :)