### PR TITLE
WASM memory accessed from instance

### DIFF
--- a/understanding-text-format/memory-export.html
+++ b/understanding-text-format/memory-export.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+
 <html>
   <head>
     <meta charset="utf-8" />

--- a/understanding-text-format/memory-export.html
+++ b/understanding-text-format/memory-export.html
@@ -1,24 +1,22 @@
-<!doctype html>
-
+<!DOCTYPE html>
 <html>
-
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>WASM memory export example</title>
   </head>
 
   <body>
     <script>
-      WebAssembly.instantiateStreaming(fetch("memory-export.wasm"))
-      .then(object => {
-        const values = new Uint32Array(object.instance.exports.memory.buffer);
-        // views only the first ten elements of the Wasm memory
-        const summands = values.subarray(0, 10);
-        // sums the first ten elements
-        const sum = summands.reduce((sum, summand) => sum + summand);
-        console.log(sum);
-      });
+      WebAssembly.instantiateStreaming(fetch("memory-export.wasm")).then(
+        (object) => {
+          const values = new Uint32Array(object.instance.exports.memory.buffer);
+          // views only the first ten elements of the Wasm memory
+          const summands = values.subarray(0, 10);
+          // sums the first ten elements
+          const sum = summands.reduce((sum, summand) => sum + summand);
+          console.log(sum);
+        }
+      );
     </script>
   </body>
-
 </html>

--- a/understanding-text-format/memory-export.html
+++ b/understanding-text-format/memory-export.html
@@ -11,7 +11,7 @@
     <script>
       WebAssembly.instantiateStreaming(fetch("memory-export.wasm"))
       .then(object => {
-        const values = new Uint32Array(object.exports.memory.buffer);
+        const values = new Uint32Array(object.instance.exports.memory.buffer);
         // views only the first ten elements of the Wasm memory
         const summands = values.subarray(0, 10);
         // sums the first ten elements


### PR DESCRIPTION
Exports (and imports) are accessed from the instance `object.instance.exports.memory.buffer` - the exports aren't defined on the returned object.

This uncovered as part of experimenting for https://github.com/mdn/content/issues/32777