### PR TITLE
ci(workflows): remove `set-default-labels` workflow

### DIFF
--- a/.github/workflows/set-default-labels.yml
+++ b/.github/workflows/set-default-labels.yml
@@ -1,9 +1,0 @@
-name: set-default-labels
-on: [workflow_dispatch]
-
-jobs:
-  set-default-labels:
-    uses: mdn/workflows/.github/workflows/set-default-labels.yml@main
-    with:
-      target-repo: "mdn/webassembly-examples"
-      should-delete-labels: true


### PR DESCRIPTION
### Description

Removes the obsolete `set-default-labels` workflow.

### Motivation

It is not used.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/927.