### PR TITLE
ci(dependabot): disable for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: ci
-      include: scope
-
   - package-ecosystem: npm
     directory: rust-js/site
     schedule:


### PR DESCRIPTION
`/.github/workflows/` doesn't exist, so there's nothing to update here yet

__edit:__ See https://github.com/mdn/webassembly-examples/actions/runs/19248182010/job/55027181550#step:3:167