### PR TITLE
docs: describe WebAssembly JavaScript API example

### DIFF
--- a/js-api-examples/index.html
+++ b/js-api-examples/index.html
@@ -8,6 +8,8 @@
   </head>
 
   <body>
+    <h1>WebAssembly JavaScript API example</h1>
+    <p>This example demonstrates how to load and instantiate a WebAssembly module using the JavaScript WebAssembly API. Open your browser's developer console to see the output.</p>
     <script>
       const importObject = {
         my_namespace: {


### PR DESCRIPTION
Adds a heading and description to the JavaScript API WebAssembly example so visitors understand what the page demonstrates and where to find its output.

Fixes #42