### PR TITLE
change anyfunc instances to funcref

### DIFF
--- a/js-api-examples/table.html
+++ b/js-api-examples/table.html
@@ -1,29 +1,26 @@
 <!doctype html>
 
 <html>
-
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>WASM table example</title>
   </head>
 
   <body>
     <script>
       const table = new WebAssembly.Table({
-        element: "anyfunc",
+        element: "funcref",
         initial: 1,
-        maximum: 10
+        maximum: 10,
       });
       table.grow(1);
-      console.log(table.length);  // 2
+      console.log(table.length); // 2
 
-      WebAssembly.instantiateStreaming(fetch("table.wasm"))
-      .then(obj => {
+      WebAssembly.instantiateStreaming(fetch("table.wasm")).then((obj) => {
         const tbl = obj.instance.exports.tbl;
-        console.log(tbl.get(0)());  // 13
-        console.log(tbl.get(1)());  // 42
+        console.log(tbl.get(0)()); // 13
+        console.log(tbl.get(1)()); // 42
       });
     </script>
   </body>
-
 </html>

--- a/js-api-examples/table2.html
+++ b/js-api-examples/table2.html
@@ -1,9 +1,8 @@
 <!doctype html>
 
 <html>
-
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Another WASM table example</title>
   </head>
 
@@ -11,23 +10,23 @@
     <script>
       const tbl = new WebAssembly.Table({
         initial: 2,
-        element: "anyfunc"
+        element: "funcref",
       });
       console.log(tbl.length); // 2
       console.log(tbl.get(0)); // null
       console.log(tbl.get(1)); // null
 
       const importObject = {
-        js: { tbl }
+        js: { tbl },
       };
 
-      WebAssembly.instantiateStreaming(fetch("table2.wasm"), importObject)
-      .then(obj => {
-        console.log(tbl.length); // 2
-        console.log(tbl.get(0)()); // 42
-        console.log(tbl.get(1)()); // 83
-      });
+      WebAssembly.instantiateStreaming(fetch("table2.wasm"), importObject).then(
+        (obj) => {
+          console.log(tbl.length); // 2
+          console.log(tbl.get(0)()); // 42
+          console.log(tbl.get(1)()); // 83
+        },
+      );
     </script>
   </body>
-
 </html>

--- a/other-examples/table-set.html
+++ b/other-examples/table-set.html
@@ -1,24 +1,22 @@
 <!doctype html>
 
 <html>
-
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Table set() example</title>
   </head>
 
   <body>
     <script>
       const otherTable = new WebAssembly.Table({
-        element: "anyfunc",
-        initial: 2
+        element: "funcref",
+        initial: 2,
       });
 
-      WebAssembly.instantiateStreaming(fetch("table.wasm"))
-      .then(obj => {
+      WebAssembly.instantiateStreaming(fetch("table.wasm")).then((obj) => {
         const { tbl } = obj.instance.exports;
-        console.log(tbl.get(0)());  // 13
-        console.log(tbl.get(1)());  // 42
+        console.log(tbl.get(0)()); // 13
+        console.log(tbl.get(1)()); // 42
 
         otherTable.set(0, tbl.get(0));
         otherTable.set(1, tbl.get(1));
@@ -28,5 +26,4 @@
       });
     </script>
   </body>
-
 </html>

--- a/understanding-text-format/shared-address-space.html
+++ b/understanding-text-format/shared-address-space.html
@@ -1,28 +1,26 @@
 <!doctype html>
 
 <html>
-
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Shared address space example</title>
   </head>
 
   <body>
     <script>
-    const importObject = {
-      js: {
-        memory: new WebAssembly.Memory({ initial: 1 }),
-        table: new WebAssembly.Table({ initial: 1, element: "anyfunc" })
-      }
-    };
+      const importObject = {
+        js: {
+          memory: new WebAssembly.Memory({ initial: 1 }),
+          table: new WebAssembly.Table({ initial: 1, element: "funcref" }),
+        },
+      };
 
-    Promise.all([
-      WebAssembly.instantiateStreaming(fetch("shared0.wasm"), importObject),
-      WebAssembly.instantiateStreaming(fetch("shared1.wasm"), importObject)
-    ]).then(results => {
-      console.log(results[1].instance.exports.doIt());  // prints 42
-    });
+      Promise.all([
+        WebAssembly.instantiateStreaming(fetch("shared0.wasm"), importObject),
+        WebAssembly.instantiateStreaming(fetch("shared1.wasm"), importObject),
+      ]).then((results) => {
+        console.log(results[1].instance.exports.doIt()); // prints 42
+      });
     </script>
   </body>
-
 </html>

--- a/wasm-sobel/change.js
+++ b/wasm-sobel/change.js
@@ -14,7 +14,7 @@
 // before the code. Then that object will be used in the code, and you
 // can continue to use Module afterwards as well.
 var Module;
-if (!Module) Module = (typeof Module !== 'undefined' ? Module : null) || {};
+if (!Module) Module = (typeof Module !== "undefined" ? Module : null) || {};
 
 // Sometimes an existing Module object exists with properties
 // meant to overwrite the default module functionality. Here
@@ -40,45 +40,51 @@ var ENVIRONMENT_IS_SHELL = false;
 // 2) We could be the application main() thread proxied to worker. (with Emscripten -s PROXY_TO_WORKER=1) (ENVIRONMENT_IS_WORKER == true, ENVIRONMENT_IS_PTHREAD == false)
 // 3) We could be an application pthread running in a worker. (ENVIRONMENT_IS_WORKER == true and ENVIRONMENT_IS_PTHREAD == true)
 
-if (Module['ENVIRONMENT']) {
-  if (Module['ENVIRONMENT'] === 'WEB') {
+if (Module["ENVIRONMENT"]) {
+  if (Module["ENVIRONMENT"] === "WEB") {
     ENVIRONMENT_IS_WEB = true;
-  } else if (Module['ENVIRONMENT'] === 'WORKER') {
+  } else if (Module["ENVIRONMENT"] === "WORKER") {
     ENVIRONMENT_IS_WORKER = true;
-  } else if (Module['ENVIRONMENT'] === 'NODE') {
+  } else if (Module["ENVIRONMENT"] === "NODE") {
     ENVIRONMENT_IS_NODE = true;
-  } else if (Module['ENVIRONMENT'] === 'SHELL') {
+  } else if (Module["ENVIRONMENT"] === "SHELL") {
     ENVIRONMENT_IS_SHELL = true;
   } else {
-    throw new Error('The provided Module[\'ENVIRONMENT\'] value is not valid. It must be one of: WEB|WORKER|NODE|SHELL.');
+    throw new Error(
+      "The provided Module['ENVIRONMENT'] value is not valid. It must be one of: WEB|WORKER|NODE|SHELL.",
+    );
   }
 } else {
-  ENVIRONMENT_IS_WEB = typeof window === 'object';
-  ENVIRONMENT_IS_WORKER = typeof importScripts === 'function';
-  ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof require === 'function' && !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_WORKER;
-  ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
+  ENVIRONMENT_IS_WEB = typeof window === "object";
+  ENVIRONMENT_IS_WORKER = typeof importScripts === "function";
+  ENVIRONMENT_IS_NODE =
+    typeof process === "object" &&
+    typeof require === "function" &&
+    !ENVIRONMENT_IS_WEB &&
+    !ENVIRONMENT_IS_WORKER;
+  ENVIRONMENT_IS_SHELL =
+    !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
 }
-
 
 if (ENVIRONMENT_IS_NODE) {
   // Expose functionality in the same simple way that the shells work
   // Note that we pollute the global namespace here, otherwise we break in node
-  if (!Module['print']) Module['print'] = console.log;
-  if (!Module['printErr']) Module['printErr'] = console.warn;
+  if (!Module["print"]) Module["print"] = console.log;
+  if (!Module["printErr"]) Module["printErr"] = console.warn;
 
   var nodeFS;
   var nodePath;
 
-  Module['read'] = function read(filename, binary) {
-    if (!nodeFS) nodeFS = require('fs');
-    if (!nodePath) nodePath = require('path');
-    filename = nodePath['normalize'](filename);
-    var ret = nodeFS['readFileSync'](filename);
+  Module["read"] = function read(filename, binary) {
+    if (!nodeFS) nodeFS = require("fs");
+    if (!nodePath) nodePath = require("path");
+    filename = nodePath["normalize"](filename);
+    var ret = nodeFS["readFileSync"](filename);
     return binary ? ret : ret.toString();
   };
 
-  Module['readBinary'] = function readBinary(filename) {
-    var ret = Module['read'](filename, true);
+  Module["readBinary"] = function readBinary(filename) {
+    var ret = Module["read"](filename, true);
     if (!ret.buffer) {
       ret = new Uint8Array(ret);
     }
@@ -86,73 +92,75 @@ if (ENVIRONMENT_IS_NODE) {
     return ret;
   };
 
-  Module['load'] = function load(f) {
+  Module["load"] = function load(f) {
     globalEval(read(f));
   };
 
-  if (!Module['thisProgram']) {
-    if (process['argv'].length > 1) {
-      Module['thisProgram'] = process['argv'][1].replace(/\\/g, '/');
+  if (!Module["thisProgram"]) {
+    if (process["argv"].length > 1) {
+      Module["thisProgram"] = process["argv"][1].replace(/\\/g, "/");
     } else {
-      Module['thisProgram'] = 'unknown-program';
+      Module["thisProgram"] = "unknown-program";
     }
   }
 
-  Module['arguments'] = process['argv'].slice(2);
+  Module["arguments"] = process["argv"].slice(2);
 
-  if (typeof module !== 'undefined') {
-    module['exports'] = Module;
+  if (typeof module !== "undefined") {
+    module["exports"] = Module;
   }
 
-  process['on']('uncaughtException', function(ex) {
+  process["on"]("uncaughtException", function (ex) {
     // suppress ExitStatus exceptions from showing an error
     if (!(ex instanceof ExitStatus)) {
       throw ex;
     }
   });
 
-  Module['inspect'] = function () { return '[Emscripten Module object]'; };
-}
-else if (ENVIRONMENT_IS_SHELL) {
-  if (!Module['print']) Module['print'] = print;
-  if (typeof printErr != 'undefined') Module['printErr'] = printErr; // not present in v8 or older sm
+  Module["inspect"] = function () {
+    return "[Emscripten Module object]";
+  };
+} else if (ENVIRONMENT_IS_SHELL) {
+  if (!Module["print"]) Module["print"] = print;
+  if (typeof printErr != "undefined") Module["printErr"] = printErr; // not present in v8 or older sm
 
-  if (typeof read != 'undefined') {
-    Module['read'] = read;
+  if (typeof read != "undefined") {
+    Module["read"] = read;
   } else {
-    Module['read'] = function read() { throw 'no read() available' };
+    Module["read"] = function read() {
+      throw "no read() available";
+    };
   }
 
-  Module['readBinary'] = function readBinary(f) {
-    if (typeof readbuffer === 'function') {
+  Module["readBinary"] = function readBinary(f) {
+    if (typeof readbuffer === "function") {
       return new Uint8Array(readbuffer(f));
     }
-    var data = read(f, 'binary');
-    assert(typeof data === 'object');
+    var data = read(f, "binary");
+    assert(typeof data === "object");
     return data;
   };
 
-  if (typeof scriptArgs != 'undefined') {
-    Module['arguments'] = scriptArgs;
-  } else if (typeof arguments != 'undefined') {
-    Module['arguments'] = arguments;
+  if (typeof scriptArgs != "undefined") {
+    Module["arguments"] = scriptArgs;
+  } else if (typeof arguments != "undefined") {
+    Module["arguments"] = arguments;
   }
-
-}
-else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
-  Module['read'] = function read(url) {
+} else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
+  Module["read"] = function read(url) {
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, false);
+    xhr.open("GET", url, false);
     xhr.send(null);
     return xhr.responseText;
   };
 
-  Module['readAsync'] = function readAsync(url, onload, onerror) {
+  Module["readAsync"] = function readAsync(url, onload, onerror) {
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, true);
-    xhr.responseType = 'arraybuffer';
+    xhr.open("GET", url, true);
+    xhr.responseType = "arraybuffer";
     xhr.onload = function xhr_onload() {
-      if (xhr.status == 200 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0
+      if (xhr.status == 200 || (xhr.status == 0 && xhr.response)) {
+        // file URLs can return 0
         onload(xhr.response);
       } else {
         onerror();
@@ -162,70 +170,77 @@ else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
     xhr.send(null);
   };
 
-  if (typeof arguments != 'undefined') {
-    Module['arguments'] = arguments;
+  if (typeof arguments != "undefined") {
+    Module["arguments"] = arguments;
   }
 
-  if (typeof console !== 'undefined') {
-    if (!Module['print']) Module['print'] = function print(x) {
-      console.log(x);
-    };
-    if (!Module['printErr']) Module['printErr'] = function printErr(x) {
-      console.warn(x);
-    };
+  if (typeof console !== "undefined") {
+    if (!Module["print"])
+      Module["print"] = function print(x) {
+        console.log(x);
+      };
+    if (!Module["printErr"])
+      Module["printErr"] = function printErr(x) {
+        console.warn(x);
+      };
   } else {
     // Probably a worker, and without console.log. We can do very little here...
     var TRY_USE_DUMP = false;
-    if (!Module['print']) Module['print'] = (TRY_USE_DUMP && (typeof(dump) !== "undefined") ? (function(x) {
-      dump(x);
-    }) : (function(x) {
-      // self.postMessage(x); // enable this if you want stdout to be sent as messages
-    }));
+    if (!Module["print"])
+      Module["print"] =
+        TRY_USE_DUMP && typeof dump !== "undefined"
+          ? function (x) {
+              dump(x);
+            }
+          : function (x) {
+              // self.postMessage(x); // enable this if you want stdout to be sent as messages
+            };
   }
 
   if (ENVIRONMENT_IS_WORKER) {
-    Module['load'] = importScripts;
+    Module["load"] = importScripts;
   }
 
-  if (typeof Module['setWindowTitle'] === 'undefined') {
-    Module['setWindowTitle'] = function(title) { document.title = title };
+  if (typeof Module["setWindowTitle"] === "undefined") {
+    Module["setWindowTitle"] = function (title) {
+      document.title = title;
+    };
   }
-}
-else {
+} else {
   // Unreachable because SHELL is dependant on the others
-  throw 'Unknown runtime environment. Where are we?';
+  throw "Unknown runtime environment. Where are we?";
 }
 
 function globalEval(x) {
   eval.call(null, x);
 }
-if (!Module['load'] && Module['read']) {
-  Module['load'] = function load(f) {
-    globalEval(Module['read'](f));
+if (!Module["load"] && Module["read"]) {
+  Module["load"] = function load(f) {
+    globalEval(Module["read"](f));
   };
 }
-if (!Module['print']) {
-  Module['print'] = function(){};
+if (!Module["print"]) {
+  Module["print"] = function () {};
 }
-if (!Module['printErr']) {
-  Module['printErr'] = Module['print'];
+if (!Module["printErr"]) {
+  Module["printErr"] = Module["print"];
 }
-if (!Module['arguments']) {
-  Module['arguments'] = [];
+if (!Module["arguments"]) {
+  Module["arguments"] = [];
 }
-if (!Module['thisProgram']) {
-  Module['thisProgram'] = './this.program';
+if (!Module["thisProgram"]) {
+  Module["thisProgram"] = "./this.program";
 }
 
 // *** Environment setup code ***
 
 // Closure helpers
-Module.print = Module['print'];
-Module.printErr = Module['printErr'];
+Module.print = Module["print"];
+Module.printErr = Module["printErr"];
 
 // Callbacks
-Module['preRun'] = [];
-Module['postRun'] = [];
+Module["preRun"] = [];
+Module["postRun"] = [];
 
 // Merge back in the overrides
 for (var key in moduleOverrides) {
@@ -236,8 +251,6 @@ for (var key in moduleOverrides) {
 // Free the object hierarchy contained in the overrides, this lets the GC
 // reclaim data used e.g. in memoryInitializerRequest, which is a large typed array.
 moduleOverrides = undefined;
-
-
 
 // {{PREAMBLE_ADDITIONS}}
 
@@ -270,19 +283,26 @@ var Runtime = {
   },
   getNativeTypeSize: function (type) {
     switch (type) {
-      case 'i1': case 'i8': return 1;
-      case 'i16': return 2;
-      case 'i32': return 4;
-      case 'i64': return 8;
-      case 'float': return 4;
-      case 'double': return 8;
+      case "i1":
+      case "i8":
+        return 1;
+      case "i16":
+        return 2;
+      case "i32":
+        return 4;
+      case "i64":
+        return 8;
+      case "float":
+        return 4;
+      case "double":
+        return 8;
       default: {
-        if (type[type.length-1] === '*') {
+        if (type[type.length - 1] === "*") {
           return Runtime.QUANTUM_SIZE; // A pointer
-        } else if (type[0] === 'i') {
+        } else if (type[0] === "i") {
           var bits = parseInt(type.substr(1));
           assert(bits % 8 === 0);
-          return bits/8;
+          return bits / 8;
         } else {
           return 0;
         }
@@ -294,7 +314,7 @@ var Runtime = {
   },
   STACK_ALIGN: 16,
   prepVararg: function (ptr, type) {
-    if (type === 'double' || type === 'i64') {
+    if (type === "double" || type === "i64") {
       // move so the load is aligned
       if (ptr & 7) {
         assert((ptr & 7) === 4);
@@ -307,15 +327,18 @@ var Runtime = {
   },
   getAlignSize: function (type, size, vararg) {
     // we align i64s and doubles on 64-bit boundaries, unlike x86
-    if (!vararg && (type == 'i64' || type == 'double')) return 8;
+    if (!vararg && (type == "i64" || type == "double")) return 8;
     if (!type) return Math.min(size, 8); // align structures internally to 64 bits
-    return Math.min(size || (type ? Runtime.getNativeFieldSize(type) : 0), Runtime.QUANTUM_SIZE);
+    return Math.min(
+      size || (type ? Runtime.getNativeFieldSize(type) : 0),
+      Runtime.QUANTUM_SIZE,
+    );
   },
   dynCall: function (sig, ptr, args) {
     if (args && args.length) {
-      return Module['dynCall_' + sig].apply(null, [ptr].concat(args));
+      return Module["dynCall_" + sig].apply(null, [ptr].concat(args));
     } else {
-      return Module['dynCall_' + sig].call(null, ptr);
+      return Module["dynCall_" + sig].call(null, ptr);
     }
   },
   functionPointers: [],
@@ -323,13 +346,13 @@ var Runtime = {
     for (var i = 0; i < Runtime.functionPointers.length; i++) {
       if (!Runtime.functionPointers[i]) {
         Runtime.functionPointers[i] = func;
-        return 2*(1 + i);
+        return 2 * (1 + i);
       }
     }
-    throw 'Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.';
+    throw "Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.";
   },
   removeFunction: function (index) {
-    Runtime.functionPointers[(index-2)/2] = null;
+    Runtime.functionPointers[(index - 2) / 2] = null;
   },
   warnOnce: function (text) {
     if (!Runtime.warnOnce.shown) Runtime.warnOnce.shown = {};
@@ -358,30 +381,61 @@ var Runtime = {
       } else {
         // general case
         sigCache[func] = function dynCall_wrapper() {
-          return Runtime.dynCall(sig, func, Array.prototype.slice.call(arguments));
+          return Runtime.dynCall(
+            sig,
+            func,
+            Array.prototype.slice.call(arguments),
+          );
         };
       }
     }
     return sigCache[func];
   },
   getCompilerSetting: function (name) {
-    throw 'You must build with -s RETAIN_COMPILER_SETTINGS=1 for Runtime.getCompilerSetting or emscripten_get_compiler_setting to work';
+    throw "You must build with -s RETAIN_COMPILER_SETTINGS=1 for Runtime.getCompilerSetting or emscripten_get_compiler_setting to work";
   },
-  stackAlloc: function (size) { var ret = STACKTOP;STACKTOP = (STACKTOP + size)|0;STACKTOP = (((STACKTOP)+15)&-16); return ret; },
-  staticAlloc: function (size) { var ret = STATICTOP;STATICTOP = (STATICTOP + size)|0;STATICTOP = (((STATICTOP)+15)&-16); return ret; },
-  dynamicAlloc: function (size) { var ret = HEAP32[DYNAMICTOP_PTR>>2];var end = (((ret + size + 15)|0) & -16);HEAP32[DYNAMICTOP_PTR>>2] = end;if (end >= TOTAL_MEMORY) {var success = enlargeMemory();if (!success) {HEAP32[DYNAMICTOP_PTR>>2] = ret;return 0;}}return ret;},
-  alignMemory: function (size,quantum) { var ret = size = Math.ceil((size)/(quantum ? quantum : 16))*(quantum ? quantum : 16); return ret; },
-  makeBigInt: function (low,high,unsigned) { var ret = (unsigned ? ((+((low>>>0)))+((+((high>>>0)))*4294967296.0)) : ((+((low>>>0)))+((+((high|0)))*4294967296.0))); return ret; },
+  stackAlloc: function (size) {
+    var ret = STACKTOP;
+    STACKTOP = (STACKTOP + size) | 0;
+    STACKTOP = (STACKTOP + 15) & -16;
+    return ret;
+  },
+  staticAlloc: function (size) {
+    var ret = STATICTOP;
+    STATICTOP = (STATICTOP + size) | 0;
+    STATICTOP = (STATICTOP + 15) & -16;
+    return ret;
+  },
+  dynamicAlloc: function (size) {
+    var ret = HEAP32[DYNAMICTOP_PTR >> 2];
+    var end = ((ret + size + 15) | 0) & -16;
+    HEAP32[DYNAMICTOP_PTR >> 2] = end;
+    if (end >= TOTAL_MEMORY) {
+      var success = enlargeMemory();
+      if (!success) {
+        HEAP32[DYNAMICTOP_PTR >> 2] = ret;
+        return 0;
+      }
+    }
+    return ret;
+  },
+  alignMemory: function (size, quantum) {
+    var ret = (size =
+      Math.ceil(size / (quantum ? quantum : 16)) * (quantum ? quantum : 16));
+    return ret;
+  },
+  makeBigInt: function (low, high, unsigned) {
+    var ret = unsigned
+      ? +(low >>> 0) + +(high >>> 0) * 4294967296.0
+      : +(low >>> 0) + +(high | 0) * 4294967296.0;
+    return ret;
+  },
   GLOBAL_BASE: 1024,
   QUANTUM_SIZE: 4,
-  __dummy__: 0
-}
-
-
+  __dummy__: 0,
+};
 
 Module["Runtime"] = Runtime;
-
-
 
 //========================================
 // Runtime essentials
@@ -392,7 +446,7 @@ var EXITSTATUS = 0;
 
 function assert(condition, text) {
   if (!condition) {
-    abort('Assertion failed: ' + text);
+    abort("Assertion failed: " + text);
   }
 }
 
@@ -400,45 +454,53 @@ var globalScope = this;
 
 // Returns the C function with a specified identifier (for C++, you need to do manual name mangling)
 function getCFunc(ident) {
-  var func = Module['_' + ident]; // closure exported function
+  var func = Module["_" + ident]; // closure exported function
   if (!func) {
-    try { func = eval('_' + ident); } catch(e) {}
+    try {
+      func = eval("_" + ident);
+    } catch (e) {}
   }
-  assert(func, 'Cannot call unknown function ' + ident + ' (perhaps LLVM optimizations or closure removed it?)');
+  assert(
+    func,
+    "Cannot call unknown function " +
+      ident +
+      " (perhaps LLVM optimizations or closure removed it?)",
+  );
   return func;
 }
 
 var cwrap, ccall;
-(function(){
+(function () {
   var JSfuncs = {
     // Helpers for cwrap -- it can't refer to Runtime directly because it might
     // be renamed by closure, instead it calls JSfuncs['stackSave'].body to find
     // out what the minified function name is.
-    'stackSave': function() {
-      Runtime.stackSave()
+    stackSave: function () {
+      Runtime.stackSave();
     },
-    'stackRestore': function() {
-      Runtime.stackRestore()
+    stackRestore: function () {
+      Runtime.stackRestore();
     },
     // type conversion from js to c
-    'arrayToC' : function(arr) {
+    arrayToC: function (arr) {
       var ret = Runtime.stackAlloc(arr.length);
       writeArrayToMemory(arr, ret);
       return ret;
     },
-    'stringToC' : function(str) {
+    stringToC: function (str) {
       var ret = 0;
-      if (str !== null && str !== undefined && str !== 0) { // null string
+      if (str !== null && str !== undefined && str !== 0) {
+        // null string
         // at most 4 bytes per UTF-8 code point, +1 for the trailing '\0'
         var len = (str.length << 2) + 1;
         ret = Runtime.stackAlloc(len);
         stringToUTF8(str, ret, len);
       }
       return ret;
-    }
+    },
   };
   // For fast lookup of conversion functions
-  var toC = {'string' : JSfuncs['stringToC'], 'array' : JSfuncs['arrayToC']};
+  var toC = { string: JSfuncs["stringToC"], array: JSfuncs["arrayToC"] };
 
   // C calling interface.
   ccall = function ccallFunc(ident, returnType, argTypes, args, opts) {
@@ -457,10 +519,10 @@ var cwrap, ccall;
       }
     }
     var ret = func.apply(null, cArgs);
-    if (returnType === 'string') ret = Pointer_stringify(ret);
+    if (returnType === "string") ret = Pointer_stringify(ret);
     if (stack !== 0) {
       if (opts && opts.async) {
-        EmterpreterAsync.asyncFinalizers.push(function() {
+        EmterpreterAsync.asyncFinalizers.push(function () {
           Runtime.stackRestore(stack);
         });
         return;
@@ -468,13 +530,14 @@ var cwrap, ccall;
       Runtime.stackRestore(stack);
     }
     return ret;
-  }
+  };
 
-  var sourceRegex = /^function\s*[a-zA-Z$_0-9]*\s*\(([^)]*)\)\s*{\s*([^*]*?)[\s;]*(?:return\s*(.*?)[;\s]*)?}$/;
+  var sourceRegex =
+    /^function\s*[a-zA-Z$_0-9]*\s*\(([^)]*)\)\s*{\s*([^*]*?)[\s;]*(?:return\s*(.*?)[;\s]*)?}$/;
   function parseJSFunc(jsfunc) {
     // Match the body and the return value of a javascript function source
     var parsed = jsfunc.toString().match(sourceRegex).slice(1);
-    return {arguments : parsed[0], body : parsed[1], returnValue: parsed[2]}
+    return { arguments: parsed[0], body: parsed[1], returnValue: parsed[2] };
   }
 
   // sources of useful functions. we create this lazily as it can trigger a source decompression on this entire file
@@ -497,45 +560,55 @@ var cwrap, ccall;
     var cfunc = getCFunc(ident);
     // When the function takes numbers and returns a number, we can just return
     // the original function
-    var numericArgs = argTypes.every(function(type){ return type === 'number'});
-    var numericRet = (returnType !== 'string');
-    if ( numericRet && numericArgs) {
+    var numericArgs = argTypes.every(function (type) {
+      return type === "number";
+    });
+    var numericRet = returnType !== "string";
+    if (numericRet && numericArgs) {
       return cfunc;
     }
     // Creation of the arguments list (["$1","$2",...,"$nargs"])
-    var argNames = argTypes.map(function(x,i){return '$'+i});
-    var funcstr = "(function(" + argNames.join(',') + ") {";
+    var argNames = argTypes.map(function (x, i) {
+      return "$" + i;
+    });
+    var funcstr = "(function(" + argNames.join(",") + ") {";
     var nargs = argTypes.length;
     if (!numericArgs) {
       // Generate the code needed to convert the arguments from javascript
       // values to pointers
       ensureJSsource();
-      funcstr += 'var stack = ' + JSsource['stackSave'].body + ';';
+      funcstr += "var stack = " + JSsource["stackSave"].body + ";";
       for (var i = 0; i < nargs; i++) {
-        var arg = argNames[i], type = argTypes[i];
-        if (type === 'number') continue;
-        var convertCode = JSsource[type + 'ToC']; // [code, return]
-        funcstr += 'var ' + convertCode.arguments + ' = ' + arg + ';';
-        funcstr += convertCode.body + ';';
-        funcstr += arg + '=(' + convertCode.returnValue + ');';
+        var arg = argNames[i],
+          type = argTypes[i];
+        if (type === "number") continue;
+        var convertCode = JSsource[type + "ToC"]; // [code, return]
+        funcstr += "var " + convertCode.arguments + " = " + arg + ";";
+        funcstr += convertCode.body + ";";
+        funcstr += arg + "=(" + convertCode.returnValue + ");";
       }
     }
 
     // When the code is compressed, the name of cfunc is not literally 'cfunc' anymore
-    var cfuncname = parseJSFunc(function(){return cfunc}).returnValue;
+    var cfuncname = parseJSFunc(function () {
+      return cfunc;
+    }).returnValue;
     // Call the function
-    funcstr += 'var ret = ' + cfuncname + '(' + argNames.join(',') + ');';
-    if (!numericRet) { // Return type can only by 'string' or 'number'
+    funcstr += "var ret = " + cfuncname + "(" + argNames.join(",") + ");";
+    if (!numericRet) {
+      // Return type can only by 'string' or 'number'
       // Convert the result to a string
-      var strgfy = parseJSFunc(function(){return Pointer_stringify}).returnValue;
-      funcstr += 'ret = ' + strgfy + '(ret);';
+      var strgfy = parseJSFunc(function () {
+        return Pointer_stringify;
+      }).returnValue;
+      funcstr += "ret = " + strgfy + "(ret);";
     }
     if (!numericArgs) {
       // If we had a stack, restore it
       ensureJSsource();
-      funcstr += JSsource['stackRestore'].body.replace('()', '(stack)') + ';';
+      funcstr += JSsource["stackRestore"].body.replace("()", "(stack)") + ";";
     }
-    funcstr += 'return ret})';
+    funcstr += "return ret})";
     return eval(funcstr);
   };
 })();
@@ -543,35 +616,71 @@ Module["ccall"] = ccall;
 Module["cwrap"] = cwrap;
 
 function setValue(ptr, value, type, noSafe) {
-  type = type || 'i8';
-  if (type.charAt(type.length-1) === '*') type = 'i32'; // pointers are 32-bit
-    switch(type) {
-      case 'i1': HEAP8[((ptr)>>0)]=value; break;
-      case 'i8': HEAP8[((ptr)>>0)]=value; break;
-      case 'i16': HEAP16[((ptr)>>1)]=value; break;
-      case 'i32': HEAP32[((ptr)>>2)]=value; break;
-      case 'i64': (tempI64 = [value>>>0,(tempDouble=value,(+(Math_abs(tempDouble))) >= 1.0 ? (tempDouble > 0.0 ? ((Math_min((+(Math_floor((tempDouble)/4294967296.0))), 4294967295.0))|0)>>>0 : (~~((+(Math_ceil((tempDouble - +(((~~(tempDouble)))>>>0))/4294967296.0)))))>>>0) : 0)],HEAP32[((ptr)>>2)]=tempI64[0],HEAP32[(((ptr)+(4))>>2)]=tempI64[1]); break;
-      case 'float': HEAPF32[((ptr)>>2)]=value; break;
-      case 'double': HEAPF64[((ptr)>>3)]=value; break;
-      default: abort('invalid type for setValue: ' + type);
-    }
+  type = type || "i8";
+  if (type.charAt(type.length - 1) === "*") type = "i32"; // pointers are 32-bit
+  switch (type) {
+    case "i1":
+      HEAP8[ptr >> 0] = value;
+      break;
+    case "i8":
+      HEAP8[ptr >> 0] = value;
+      break;
+    case "i16":
+      HEAP16[ptr >> 1] = value;
+      break;
+    case "i32":
+      HEAP32[ptr >> 2] = value;
+      break;
+    case "i64":
+      ((tempI64 = [
+        value >>> 0,
+        ((tempDouble = value),
+        +Math_abs(tempDouble) >= 1.0
+          ? tempDouble > 0.0
+            ? (Math_min(+Math_floor(tempDouble / 4294967296.0), 4294967295.0) |
+                0) >>>
+              0
+            : ~~+Math_ceil(
+                (tempDouble - +(~~tempDouble >>> 0)) / 4294967296.0,
+              ) >>> 0
+          : 0),
+      ]),
+        (HEAP32[ptr >> 2] = tempI64[0]),
+        (HEAP32[(ptr + 4) >> 2] = tempI64[1]));
+      break;
+    case "float":
+      HEAPF32[ptr >> 2] = value;
+      break;
+    case "double":
+      HEAPF64[ptr >> 3] = value;
+      break;
+    default:
+      abort("invalid type for setValue: " + type);
+  }
 }
 Module["setValue"] = setValue;
 
-
 function getValue(ptr, type, noSafe) {
-  type = type || 'i8';
-  if (type.charAt(type.length-1) === '*') type = 'i32'; // pointers are 32-bit
-    switch(type) {
-      case 'i1': return HEAP8[((ptr)>>0)];
-      case 'i8': return HEAP8[((ptr)>>0)];
-      case 'i16': return HEAP16[((ptr)>>1)];
-      case 'i32': return HEAP32[((ptr)>>2)];
-      case 'i64': return HEAP32[((ptr)>>2)];
-      case 'float': return HEAPF32[((ptr)>>2)];
-      case 'double': return HEAPF64[((ptr)>>3)];
-      default: abort('invalid type for setValue: ' + type);
-    }
+  type = type || "i8";
+  if (type.charAt(type.length - 1) === "*") type = "i32"; // pointers are 32-bit
+  switch (type) {
+    case "i1":
+      return HEAP8[ptr >> 0];
+    case "i8":
+      return HEAP8[ptr >> 0];
+    case "i16":
+      return HEAP16[ptr >> 1];
+    case "i32":
+      return HEAP32[ptr >> 2];
+    case "i64":
+      return HEAP32[ptr >> 2];
+    case "float":
+      return HEAPF32[ptr >> 2];
+    case "double":
+      return HEAPF64[ptr >> 3];
+    default:
+      abort("invalid type for setValue: " + type);
+  }
   return null;
 }
 Module["getValue"] = getValue;
@@ -602,7 +711,7 @@ Module["ALLOC_NONE"] = ALLOC_NONE;
 // @allocator: How to allocate memory, see ALLOC_*
 function allocate(slab, types, allocator, ptr) {
   var zeroinit, size;
-  if (typeof slab === 'number') {
+  if (typeof slab === "number") {
     zeroinit = true;
     size = slab;
   } else {
@@ -610,30 +719,38 @@ function allocate(slab, types, allocator, ptr) {
     size = slab.length;
   }
 
-  var singleType = typeof types === 'string' ? types : null;
+  var singleType = typeof types === "string" ? types : null;
 
   var ret;
   if (allocator == ALLOC_NONE) {
     ret = ptr;
   } else {
-    ret = [typeof _malloc === 'function' ? _malloc : Runtime.staticAlloc, Runtime.stackAlloc, Runtime.staticAlloc, Runtime.dynamicAlloc][allocator === undefined ? ALLOC_STATIC : allocator](Math.max(size, singleType ? 1 : types.length));
+    ret = [
+      typeof _malloc === "function" ? _malloc : Runtime.staticAlloc,
+      Runtime.stackAlloc,
+      Runtime.staticAlloc,
+      Runtime.dynamicAlloc,
+    ][allocator === undefined ? ALLOC_STATIC : allocator](
+      Math.max(size, singleType ? 1 : types.length),
+    );
   }
 
   if (zeroinit) {
-    var ptr = ret, stop;
+    var ptr = ret,
+      stop;
     assert((ret & 3) == 0);
     stop = ret + (size & ~3);
     for (; ptr < stop; ptr += 4) {
-      HEAP32[((ptr)>>2)]=0;
+      HEAP32[ptr >> 2] = 0;
     }
     stop = ret + size;
     while (ptr < stop) {
-      HEAP8[((ptr++)>>0)]=0;
+      HEAP8[ptr++ >> 0] = 0;
     }
     return ret;
   }
 
-  if (singleType === 'i8') {
+  if (singleType === "i8") {
     if (slab.subarray || slab.slice) {
       HEAPU8.set(slab, ret);
     } else {
@@ -642,11 +759,14 @@ function allocate(slab, types, allocator, ptr) {
     return ret;
   }
 
-  var i = 0, type, typeSize, previousType;
+  var i = 0,
+    type,
+    typeSize,
+    previousType;
   while (i < size) {
     var curr = slab[i];
 
-    if (typeof curr === 'function') {
+    if (typeof curr === "function") {
       curr = Runtime.getFunctionIndex(curr);
     }
 
@@ -656,9 +776,9 @@ function allocate(slab, types, allocator, ptr) {
       continue;
     }
 
-    if (type == 'i64') type = 'i32'; // special case: we have one i32 here, and one i32 later
+    if (type == "i64") type = "i32"; // special case: we have one i32 here, and one i32 later
 
-    setValue(ret+i, curr, type);
+    setValue(ret + i, curr, type);
 
     // no need to look up size unless type changes, so cache it
     if (previousType !== type) {
@@ -681,14 +801,14 @@ function getMemory(size) {
 Module["getMemory"] = getMemory;
 
 function Pointer_stringify(ptr, /* optional */ length) {
-  if (length === 0 || !ptr) return '';
+  if (length === 0 || !ptr) return "";
   // TODO: use TextDecoder
   // Find the length, and check for UTF while doing so
   var hasUtf = 0;
   var t;
   var i = 0;
   while (1) {
-    t = HEAPU8[(((ptr)+(i))>>0)];
+    t = HEAPU8[(ptr + i) >> 0];
     hasUtf |= t;
     if (t == 0 && !length) break;
     i++;
@@ -696,20 +816,23 @@ function Pointer_stringify(ptr, /* optional */ length) {
   }
   if (!length) length = i;
 
-  var ret = '';
+  var ret = "";
 
   if (hasUtf < 128) {
     var MAX_CHUNK = 1024; // split up into chunks, because .apply on a huge string can overflow the stack
     var curr;
     while (length > 0) {
-      curr = String.fromCharCode.apply(String, HEAPU8.subarray(ptr, ptr + Math.min(length, MAX_CHUNK)));
+      curr = String.fromCharCode.apply(
+        String,
+        HEAPU8.subarray(ptr, ptr + Math.min(length, MAX_CHUNK)),
+      );
       ret = ret ? ret + curr : curr;
       ptr += MAX_CHUNK;
       length -= MAX_CHUNK;
     }
     return ret;
   }
-  return Module['UTF8ToString'](ptr);
+  return Module["UTF8ToString"](ptr);
 }
 Module["Pointer_stringify"] = Pointer_stringify;
 
@@ -717,9 +840,9 @@ Module["Pointer_stringify"] = Pointer_stringify;
 // a copy of that string as a Javascript String object.
 
 function AsciiToString(ptr) {
-  var str = '';
+  var str = "";
   while (1) {
-    var ch = HEAP8[((ptr++)>>0)];
+    var ch = HEAP8[ptr++ >> 0];
     if (!ch) return str;
     str += String.fromCharCode(ch);
   }
@@ -737,7 +860,8 @@ Module["stringToAscii"] = stringToAscii;
 // Given a pointer 'ptr' to a null-terminated UTF8-encoded string in the given array that contains uint8 values, returns
 // a copy of that string as a Javascript String object.
 
-var UTF8Decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder('utf8') : undefined;
+var UTF8Decoder =
+  typeof TextDecoder !== "undefined" ? new TextDecoder("utf8") : undefined;
 function UTF8ArrayToString(u8Array, idx) {
   var endPtr = idx;
   // TextDecoder needs to know the byte length in advance, it doesn't stop on null terminator by itself.
@@ -749,28 +873,40 @@ function UTF8ArrayToString(u8Array, idx) {
   } else {
     var u0, u1, u2, u3, u4, u5;
 
-    var str = '';
+    var str = "";
     while (1) {
       // For UTF8 byte structure, see http://en.wikipedia.org/wiki/UTF-8#Description and https://www.ietf.org/rfc/rfc2279.txt and https://tools.ietf.org/html/rfc3629
       u0 = u8Array[idx++];
       if (!u0) return str;
-      if (!(u0 & 0x80)) { str += String.fromCharCode(u0); continue; }
+      if (!(u0 & 0x80)) {
+        str += String.fromCharCode(u0);
+        continue;
+      }
       u1 = u8Array[idx++] & 63;
-      if ((u0 & 0xE0) == 0xC0) { str += String.fromCharCode(((u0 & 31) << 6) | u1); continue; }
+      if ((u0 & 0xe0) == 0xc0) {
+        str += String.fromCharCode(((u0 & 31) << 6) | u1);
+        continue;
+      }
       u2 = u8Array[idx++] & 63;
-      if ((u0 & 0xF0) == 0xE0) {
+      if ((u0 & 0xf0) == 0xe0) {
         u0 = ((u0 & 15) << 12) | (u1 << 6) | u2;
       } else {
         u3 = u8Array[idx++] & 63;
-        if ((u0 & 0xF8) == 0xF0) {
+        if ((u0 & 0xf8) == 0xf0) {
           u0 = ((u0 & 7) << 18) | (u1 << 12) | (u2 << 6) | u3;
         } else {
           u4 = u8Array[idx++] & 63;
-          if ((u0 & 0xFC) == 0xF8) {
+          if ((u0 & 0xfc) == 0xf8) {
             u0 = ((u0 & 3) << 24) | (u1 << 18) | (u2 << 12) | (u3 << 6) | u4;
           } else {
             u5 = u8Array[idx++] & 63;
-            u0 = ((u0 & 1) << 30) | (u1 << 24) | (u2 << 18) | (u3 << 12) | (u4 << 6) | u5;
+            u0 =
+              ((u0 & 1) << 30) |
+              (u1 << 24) |
+              (u2 << 18) |
+              (u3 << 12) |
+              (u4 << 6) |
+              u5;
           }
         }
       }
@@ -778,7 +914,7 @@ function UTF8ArrayToString(u8Array, idx) {
         str += String.fromCharCode(u0);
       } else {
         var ch = u0 - 0x10000;
-        str += String.fromCharCode(0xD800 | (ch >> 10), 0xDC00 | (ch & 0x3FF));
+        str += String.fromCharCode(0xd800 | (ch >> 10), 0xdc00 | (ch & 0x3ff));
       }
     }
   }
@@ -789,7 +925,7 @@ Module["UTF8ArrayToString"] = UTF8ArrayToString;
 // a copy of that string as a Javascript String object.
 
 function UTF8ToString(ptr) {
-  return UTF8ArrayToString(HEAPU8,ptr);
+  return UTF8ArrayToString(HEAPU8, ptr);
 }
 Module["UTF8ToString"] = UTF8ToString;
 
@@ -806,7 +942,8 @@ Module["UTF8ToString"] = UTF8ToString;
 // Returns the number of bytes written, EXCLUDING the null terminator.
 
 function stringToUTF8Array(str, outU8Array, outIdx, maxBytesToWrite) {
-  if (!(maxBytesToWrite > 0)) // Parameter maxBytesToWrite is not optional. Negative values, 0, null, undefined and false each don't write out any bytes.
+  if (!(maxBytesToWrite > 0))
+    // Parameter maxBytesToWrite is not optional. Negative values, 0, null, undefined and false each don't write out any bytes.
     return 0;
 
   var startIdx = outIdx;
@@ -816,35 +953,36 @@ function stringToUTF8Array(str, outU8Array, outIdx, maxBytesToWrite) {
     // See http://unicode.org/faq/utf_bom.html#utf16-3
     // For UTF8 byte structure, see http://en.wikipedia.org/wiki/UTF-8#Description and https://www.ietf.org/rfc/rfc2279.txt and https://tools.ietf.org/html/rfc3629
     var u = str.charCodeAt(i); // possibly a lead surrogate
-    if (u >= 0xD800 && u <= 0xDFFF) u = 0x10000 + ((u & 0x3FF) << 10) | (str.charCodeAt(++i) & 0x3FF);
-    if (u <= 0x7F) {
+    if (u >= 0xd800 && u <= 0xdfff)
+      u = (0x10000 + ((u & 0x3ff) << 10)) | (str.charCodeAt(++i) & 0x3ff);
+    if (u <= 0x7f) {
       if (outIdx >= endIdx) break;
       outU8Array[outIdx++] = u;
-    } else if (u <= 0x7FF) {
+    } else if (u <= 0x7ff) {
       if (outIdx + 1 >= endIdx) break;
-      outU8Array[outIdx++] = 0xC0 | (u >> 6);
+      outU8Array[outIdx++] = 0xc0 | (u >> 6);
       outU8Array[outIdx++] = 0x80 | (u & 63);
-    } else if (u <= 0xFFFF) {
+    } else if (u <= 0xffff) {
       if (outIdx + 2 >= endIdx) break;
-      outU8Array[outIdx++] = 0xE0 | (u >> 12);
+      outU8Array[outIdx++] = 0xe0 | (u >> 12);
       outU8Array[outIdx++] = 0x80 | ((u >> 6) & 63);
       outU8Array[outIdx++] = 0x80 | (u & 63);
-    } else if (u <= 0x1FFFFF) {
+    } else if (u <= 0x1fffff) {
       if (outIdx + 3 >= endIdx) break;
-      outU8Array[outIdx++] = 0xF0 | (u >> 18);
+      outU8Array[outIdx++] = 0xf0 | (u >> 18);
       outU8Array[outIdx++] = 0x80 | ((u >> 12) & 63);
       outU8Array[outIdx++] = 0x80 | ((u >> 6) & 63);
       outU8Array[outIdx++] = 0x80 | (u & 63);
-    } else if (u <= 0x3FFFFFF) {
+    } else if (u <= 0x3ffffff) {
       if (outIdx + 4 >= endIdx) break;
-      outU8Array[outIdx++] = 0xF8 | (u >> 24);
+      outU8Array[outIdx++] = 0xf8 | (u >> 24);
       outU8Array[outIdx++] = 0x80 | ((u >> 18) & 63);
       outU8Array[outIdx++] = 0x80 | ((u >> 12) & 63);
       outU8Array[outIdx++] = 0x80 | ((u >> 6) & 63);
       outU8Array[outIdx++] = 0x80 | (u & 63);
     } else {
       if (outIdx + 5 >= endIdx) break;
-      outU8Array[outIdx++] = 0xFC | (u >> 30);
+      outU8Array[outIdx++] = 0xfc | (u >> 30);
       outU8Array[outIdx++] = 0x80 | ((u >> 24) & 63);
       outU8Array[outIdx++] = 0x80 | ((u >> 18) & 63);
       outU8Array[outIdx++] = 0x80 | ((u >> 12) & 63);
@@ -864,7 +1002,7 @@ Module["stringToUTF8Array"] = stringToUTF8Array;
 // Returns the number of bytes written, EXCLUDING the null terminator.
 
 function stringToUTF8(str, outPtr, maxBytesToWrite) {
-  return stringToUTF8Array(str, HEAPU8,outPtr, maxBytesToWrite);
+  return stringToUTF8Array(str, HEAPU8, outPtr, maxBytesToWrite);
 }
 Module["stringToUTF8"] = stringToUTF8;
 
@@ -876,16 +1014,17 @@ function lengthBytesUTF8(str) {
     // Gotcha: charCodeAt returns a 16-bit word that is a UTF-16 encoded code unit, not a Unicode code point of the character! So decode UTF16->UTF32->UTF8.
     // See http://unicode.org/faq/utf_bom.html#utf16-3
     var u = str.charCodeAt(i); // possibly a lead surrogate
-    if (u >= 0xD800 && u <= 0xDFFF) u = 0x10000 + ((u & 0x3FF) << 10) | (str.charCodeAt(++i) & 0x3FF);
-    if (u <= 0x7F) {
+    if (u >= 0xd800 && u <= 0xdfff)
+      u = (0x10000 + ((u & 0x3ff) << 10)) | (str.charCodeAt(++i) & 0x3ff);
+    if (u <= 0x7f) {
       ++len;
-    } else if (u <= 0x7FF) {
+    } else if (u <= 0x7ff) {
       len += 2;
-    } else if (u <= 0xFFFF) {
+    } else if (u <= 0xffff) {
       len += 3;
-    } else if (u <= 0x1FFFFF) {
+    } else if (u <= 0x1fffff) {
       len += 4;
-    } else if (u <= 0x3FFFFFF) {
+    } else if (u <= 0x3ffffff) {
       len += 5;
     } else {
       len += 6;
@@ -898,7 +1037,8 @@ Module["lengthBytesUTF8"] = lengthBytesUTF8;
 // Given a pointer 'ptr' to a null-terminated UTF16LE-encoded string in the emscripten HEAP, returns
 // a copy of that string as a Javascript String object.
 
-var UTF16Decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-16le') : undefined;
+var UTF16Decoder =
+  typeof TextDecoder !== "undefined" ? new TextDecoder("utf-16le") : undefined;
 function UTF16ToString(ptr) {
   var endPtr = ptr;
   // TextDecoder needs to know the byte length in advance, it doesn't stop on null terminator by itself.
@@ -912,9 +1052,9 @@ function UTF16ToString(ptr) {
   } else {
     var i = 0;
 
-    var str = '';
+    var str = "";
     while (1) {
-      var codeUnit = HEAP16[(((ptr)+(i*2))>>1)];
+      var codeUnit = HEAP16[(ptr + i * 2) >> 1];
       if (codeUnit == 0) return str;
       ++i;
       // fromCharCode constructs a character from a UTF-16 code unit, so we can pass the UTF16 string right through.
@@ -922,7 +1062,6 @@ function UTF16ToString(ptr) {
     }
   }
 }
-
 
 // Copies the given Javascript String object 'str' to the emscripten HEAP at address 'outPtr',
 // null-terminated and encoded in UTF16 form. The copy will require at most str.length*4+2 bytes of space in the HEAP.
@@ -938,51 +1077,48 @@ function UTF16ToString(ptr) {
 function stringToUTF16(str, outPtr, maxBytesToWrite) {
   // Backwards compatibility: if max bytes is not specified, assume unsafe unbounded write is allowed.
   if (maxBytesToWrite === undefined) {
-    maxBytesToWrite = 0x7FFFFFFF;
+    maxBytesToWrite = 0x7fffffff;
   }
   if (maxBytesToWrite < 2) return 0;
   maxBytesToWrite -= 2; // Null terminator.
   var startPtr = outPtr;
-  var numCharsToWrite = (maxBytesToWrite < str.length*2) ? (maxBytesToWrite / 2) : str.length;
+  var numCharsToWrite =
+    maxBytesToWrite < str.length * 2 ? maxBytesToWrite / 2 : str.length;
   for (var i = 0; i < numCharsToWrite; ++i) {
     // charCodeAt returns a UTF-16 encoded code unit, so it can be directly written to the HEAP.
     var codeUnit = str.charCodeAt(i); // possibly a lead surrogate
-    HEAP16[((outPtr)>>1)]=codeUnit;
+    HEAP16[outPtr >> 1] = codeUnit;
     outPtr += 2;
   }
   // Null-terminate the pointer to the HEAP.
-  HEAP16[((outPtr)>>1)]=0;
+  HEAP16[outPtr >> 1] = 0;
   return outPtr - startPtr;
 }
-
 
 // Returns the number of bytes the given Javascript string takes if encoded as a UTF16 byte array, EXCLUDING the null terminator byte.
 
 function lengthBytesUTF16(str) {
-  return str.length*2;
+  return str.length * 2;
 }
-
 
 function UTF32ToString(ptr) {
   var i = 0;
 
-  var str = '';
+  var str = "";
   while (1) {
-    var utf32 = HEAP32[(((ptr)+(i*4))>>2)];
-    if (utf32 == 0)
-      return str;
+    var utf32 = HEAP32[(ptr + i * 4) >> 2];
+    if (utf32 == 0) return str;
     ++i;
     // Gotcha: fromCharCode constructs a character from a UTF-16 encoded code (pair), not from a Unicode code point! So encode the code point to UTF-16 for constructing.
     // See http://unicode.org/faq/utf_bom.html#utf16-3
     if (utf32 >= 0x10000) {
       var ch = utf32 - 0x10000;
-      str += String.fromCharCode(0xD800 | (ch >> 10), 0xDC00 | (ch & 0x3FF));
+      str += String.fromCharCode(0xd800 | (ch >> 10), 0xdc00 | (ch & 0x3ff));
     } else {
       str += String.fromCharCode(utf32);
     }
   }
 }
-
 
 // Copies the given Javascript String object 'str' to the emscripten HEAP at address 'outPtr',
 // null-terminated and encoded in UTF32 form. The copy will require at most str.length*4+4 bytes of space in the HEAP.
@@ -998,7 +1134,7 @@ function UTF32ToString(ptr) {
 function stringToUTF32(str, outPtr, maxBytesToWrite) {
   // Backwards compatibility: if max bytes is not specified, assume unsafe unbounded write is allowed.
   if (maxBytesToWrite === undefined) {
-    maxBytesToWrite = 0x7FFFFFFF;
+    maxBytesToWrite = 0x7fffffff;
   }
   if (maxBytesToWrite < 4) return 0;
   var startPtr = outPtr;
@@ -1007,19 +1143,19 @@ function stringToUTF32(str, outPtr, maxBytesToWrite) {
     // Gotcha: charCodeAt returns a 16-bit word that is a UTF-16 encoded code unit, not a Unicode code point of the character! We must decode the string to UTF-32 to the heap.
     // See http://unicode.org/faq/utf_bom.html#utf16-3
     var codeUnit = str.charCodeAt(i); // possibly a lead surrogate
-    if (codeUnit >= 0xD800 && codeUnit <= 0xDFFF) {
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdfff) {
       var trailSurrogate = str.charCodeAt(++i);
-      codeUnit = 0x10000 + ((codeUnit & 0x3FF) << 10) | (trailSurrogate & 0x3FF);
+      codeUnit =
+        (0x10000 + ((codeUnit & 0x3ff) << 10)) | (trailSurrogate & 0x3ff);
     }
-    HEAP32[((outPtr)>>2)]=codeUnit;
+    HEAP32[outPtr >> 2] = codeUnit;
     outPtr += 4;
     if (outPtr + 4 > endPtr) break;
   }
   // Null-terminate the pointer to the HEAP.
-  HEAP32[((outPtr)>>2)]=0;
+  HEAP32[outPtr >> 2] = 0;
   return outPtr - startPtr;
 }
-
 
 // Returns the number of bytes the given Javascript string takes if encoded as a UTF16 byte array, EXCLUDING the null terminator byte.
 
@@ -1029,30 +1165,29 @@ function lengthBytesUTF32(str) {
     // Gotcha: charCodeAt returns a 16-bit word that is a UTF-16 encoded code unit, not a Unicode code point of the character! We must decode the string to UTF-32 to the heap.
     // See http://unicode.org/faq/utf_bom.html#utf16-3
     var codeUnit = str.charCodeAt(i);
-    if (codeUnit >= 0xD800 && codeUnit <= 0xDFFF) ++i; // possibly a lead surrogate, so skip over the tail surrogate.
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdfff) ++i; // possibly a lead surrogate, so skip over the tail surrogate.
     len += 4;
   }
 
   return len;
 }
 
-
 function demangle(func) {
-  var __cxa_demangle_func = Module['___cxa_demangle'] || Module['__cxa_demangle'];
+  var __cxa_demangle_func =
+    Module["___cxa_demangle"] || Module["__cxa_demangle"];
   if (__cxa_demangle_func) {
     try {
-      var s =
-        func.substr(1);
-      var len = lengthBytesUTF8(s)+1;
+      var s = func.substr(1);
+      var len = lengthBytesUTF8(s) + 1;
       var buf = _malloc(len);
       stringToUTF8(s, buf, len);
       var status = _malloc(4);
       var ret = __cxa_demangle_func(buf, 0, 0, status);
-      if (getValue(status, 'i32') === 0 && ret) {
+      if (getValue(status, "i32") === 0 && ret) {
         return Pointer_stringify(ret);
       }
       // otherwise, libcxxabi failed
-    } catch(e) {
+    } catch (e) {
       // ignore problems here
     } finally {
       if (buf) _free(buf);
@@ -1062,18 +1197,18 @@ function demangle(func) {
     // failure when using libcxxabi, don't demangle
     return func;
   }
-  Runtime.warnOnce('warning: build with  -s DEMANGLE_SUPPORT=1  to link in libcxxabi demangling');
+  Runtime.warnOnce(
+    "warning: build with  -s DEMANGLE_SUPPORT=1  to link in libcxxabi demangling",
+  );
   return func;
 }
 
 function demangleAll(text) {
-  var regex =
-    /__Z[\w\d_]+/g;
-  return text.replace(regex,
-    function(x) {
-      var y = demangle(x);
-      return x === y ? x : (x + ' [' + y + ']');
-    });
+  var regex = /__Z[\w\d_]+/g;
+  return text.replace(regex, function (x) {
+    var y = demangle(x);
+    return x === y ? x : x + " [" + y + "]";
+  });
 }
 
 function jsStackTrace() {
@@ -1083,11 +1218,11 @@ function jsStackTrace() {
     // so try that as a special-case.
     try {
       throw new Error(0);
-    } catch(e) {
+    } catch (e) {
       err = e;
     }
     if (!err.stack) {
-      return '(no stack trace available)';
+      return "(no stack trace available)";
     }
   }
   return err.stack.toString();
@@ -1095,7 +1230,7 @@ function jsStackTrace() {
 
 function stackTrace() {
   var js = jsStackTrace();
-  if (Module['extraStackTrace']) js += '\n' + Module['extraStackTrace']();
+  if (Module["extraStackTrace"]) js += "\n" + Module["extraStackTrace"]();
   return demangleAll(js);
 }
 Module["stackTrace"] = stackTrace;
@@ -1119,96 +1254,113 @@ var buffer;
 var HEAP8, HEAPU8, HEAP16, HEAPU16, HEAP32, HEAPU32, HEAPF32, HEAPF64;
 
 function updateGlobalBuffer(buf) {
-  Module['buffer'] = buffer = buf;
+  Module["buffer"] = buffer = buf;
 }
 
 function updateGlobalBufferViews() {
-  Module['HEAP8'] = HEAP8 = new Int8Array(buffer);
-  Module['HEAP16'] = HEAP16 = new Int16Array(buffer);
-  Module['HEAP32'] = HEAP32 = new Int32Array(buffer);
-  Module['HEAPU8'] = HEAPU8 = new Uint8Array(buffer);
-  Module['HEAPU16'] = HEAPU16 = new Uint16Array(buffer);
-  Module['HEAPU32'] = HEAPU32 = new Uint32Array(buffer);
-  Module['HEAPF32'] = HEAPF32 = new Float32Array(buffer);
-  Module['HEAPF64'] = HEAPF64 = new Float64Array(buffer);
+  Module["HEAP8"] = HEAP8 = new Int8Array(buffer);
+  Module["HEAP16"] = HEAP16 = new Int16Array(buffer);
+  Module["HEAP32"] = HEAP32 = new Int32Array(buffer);
+  Module["HEAPU8"] = HEAPU8 = new Uint8Array(buffer);
+  Module["HEAPU16"] = HEAPU16 = new Uint16Array(buffer);
+  Module["HEAPU32"] = HEAPU32 = new Uint32Array(buffer);
+  Module["HEAPF32"] = HEAPF32 = new Float32Array(buffer);
+  Module["HEAPF64"] = HEAPF64 = new Float64Array(buffer);
 }
 
 var STATIC_BASE, STATICTOP, staticSealed; // static area
 var STACK_BASE, STACKTOP, STACK_MAX; // stack area
 var DYNAMIC_BASE, DYNAMICTOP_PTR; // dynamic area handled by sbrk
 
-  STATIC_BASE = STATICTOP = STACK_BASE = STACKTOP = STACK_MAX = DYNAMIC_BASE = DYNAMICTOP_PTR = 0;
-  staticSealed = false;
-
-
+STATIC_BASE =
+  STATICTOP =
+  STACK_BASE =
+  STACKTOP =
+  STACK_MAX =
+  DYNAMIC_BASE =
+  DYNAMICTOP_PTR =
+    0;
+staticSealed = false;
 
 function abortOnCannotGrowMemory() {
-  abort('Cannot enlarge memory arrays. Either (1) compile with  -s TOTAL_MEMORY=X  with X higher than the current value ' + TOTAL_MEMORY + ', (2) compile with  -s ALLOW_MEMORY_GROWTH=1  which adjusts the size at runtime but prevents some optimizations, (3) set Module.TOTAL_MEMORY to a higher value before the program runs, or if you want malloc to return NULL (0) instead of this abort, compile with  -s ABORTING_MALLOC=0 ');
+  abort(
+    "Cannot enlarge memory arrays. Either (1) compile with  -s TOTAL_MEMORY=X  with X higher than the current value " +
+      TOTAL_MEMORY +
+      ", (2) compile with  -s ALLOW_MEMORY_GROWTH=1  which adjusts the size at runtime but prevents some optimizations, (3) set Module.TOTAL_MEMORY to a higher value before the program runs, or if you want malloc to return NULL (0) instead of this abort, compile with  -s ABORTING_MALLOC=0 ",
+  );
 }
-
 
 function enlargeMemory() {
   abortOnCannotGrowMemory();
 }
 
-
-var TOTAL_STACK = Module['TOTAL_STACK'] || 5242880;
-var TOTAL_MEMORY = Module['TOTAL_MEMORY'] || 16777216;
-if (TOTAL_MEMORY < TOTAL_STACK) Module.printErr('TOTAL_MEMORY should be larger than TOTAL_STACK, was ' + TOTAL_MEMORY + '! (TOTAL_STACK=' + TOTAL_STACK + ')');
+var TOTAL_STACK = Module["TOTAL_STACK"] || 5242880;
+var TOTAL_MEMORY = Module["TOTAL_MEMORY"] || 16777216;
+if (TOTAL_MEMORY < TOTAL_STACK)
+  Module.printErr(
+    "TOTAL_MEMORY should be larger than TOTAL_STACK, was " +
+      TOTAL_MEMORY +
+      "! (TOTAL_STACK=" +
+      TOTAL_STACK +
+      ")",
+  );
 
 // Initialize the runtime's memory
 
-
-
 // Use a provided buffer, if there is one, or else allocate a new one
-if (Module['buffer']) {
-  buffer = Module['buffer'];
+if (Module["buffer"]) {
+  buffer = Module["buffer"];
 } else {
   // Use a WebAssembly memory where available
-  if (typeof WebAssembly === 'object' && typeof WebAssembly.Memory === 'function') {
-    Module['wasmMemory'] = new WebAssembly.Memory({ initial: TOTAL_MEMORY / WASM_PAGE_SIZE, maximum: TOTAL_MEMORY / WASM_PAGE_SIZE });
-    buffer = Module['wasmMemory'].buffer;
-  } else
-  {
+  if (
+    typeof WebAssembly === "object" &&
+    typeof WebAssembly.Memory === "function"
+  ) {
+    Module["wasmMemory"] = new WebAssembly.Memory({
+      initial: TOTAL_MEMORY / WASM_PAGE_SIZE,
+      maximum: TOTAL_MEMORY / WASM_PAGE_SIZE,
+    });
+    buffer = Module["wasmMemory"].buffer;
+  } else {
     buffer = new ArrayBuffer(TOTAL_MEMORY);
   }
 }
 updateGlobalBufferViews();
-
 
 function getTotalMemory() {
   return TOTAL_MEMORY;
 }
 
 // Endianness check (note: assumes compiler arch was little-endian)
-  HEAP32[0] = 0x63736d65; /* 'emsc' */
+HEAP32[0] = 0x63736d65; /* 'emsc' */
 HEAP16[1] = 0x6373;
-if (HEAPU8[2] !== 0x73 || HEAPU8[3] !== 0x63) throw 'Runtime error: expected the system to be little-endian!';
+if (HEAPU8[2] !== 0x73 || HEAPU8[3] !== 0x63)
+  throw "Runtime error: expected the system to be little-endian!";
 
-Module['HEAP'] = HEAP;
-Module['buffer'] = buffer;
-Module['HEAP8'] = HEAP8;
-Module['HEAP16'] = HEAP16;
-Module['HEAP32'] = HEAP32;
-Module['HEAPU8'] = HEAPU8;
-Module['HEAPU16'] = HEAPU16;
-Module['HEAPU32'] = HEAPU32;
-Module['HEAPF32'] = HEAPF32;
-Module['HEAPF64'] = HEAPF64;
+Module["HEAP"] = HEAP;
+Module["buffer"] = buffer;
+Module["HEAP8"] = HEAP8;
+Module["HEAP16"] = HEAP16;
+Module["HEAP32"] = HEAP32;
+Module["HEAPU8"] = HEAPU8;
+Module["HEAPU16"] = HEAPU16;
+Module["HEAPU32"] = HEAPU32;
+Module["HEAPF32"] = HEAPF32;
+Module["HEAPF64"] = HEAPF64;
 
 function callRuntimeCallbacks(callbacks) {
-  while(callbacks.length > 0) {
+  while (callbacks.length > 0) {
     var callback = callbacks.shift();
-    if (typeof callback == 'function') {
+    if (typeof callback == "function") {
       callback();
       continue;
     }
     var func = callback.func;
-    if (typeof func === 'number') {
+    if (typeof func === "number") {
       if (callback.arg === undefined) {
-        Module['dynCall_v'](func);
+        Module["dynCall_v"](func);
       } else {
-        Module['dynCall_vi'](func, callback.arg);
+        Module["dynCall_vi"](func, callback.arg);
       }
     } else {
       func(callback.arg === undefined ? null : callback.arg);
@@ -1216,22 +1368,22 @@ function callRuntimeCallbacks(callbacks) {
   }
 }
 
-var __ATPRERUN__  = []; // functions called before the runtime is initialized
-var __ATINIT__    = []; // functions called during startup
-var __ATMAIN__    = []; // functions called when main() is to be run
-var __ATEXIT__    = []; // functions called during shutdown
+var __ATPRERUN__ = []; // functions called before the runtime is initialized
+var __ATINIT__ = []; // functions called during startup
+var __ATMAIN__ = []; // functions called when main() is to be run
+var __ATEXIT__ = []; // functions called during shutdown
 var __ATPOSTRUN__ = []; // functions called after the runtime has exited
 
 var runtimeInitialized = false;
 var runtimeExited = false;
 
-
 function preRun() {
   // compatibility - merge in anything from Module['preRun'] at this time
-  if (Module['preRun']) {
-    if (typeof Module['preRun'] == 'function') Module['preRun'] = [Module['preRun']];
-    while (Module['preRun'].length) {
-      addOnPreRun(Module['preRun'].shift());
+  if (Module["preRun"]) {
+    if (typeof Module["preRun"] == "function")
+      Module["preRun"] = [Module["preRun"]];
+    while (Module["preRun"].length) {
+      addOnPreRun(Module["preRun"].shift());
     }
   }
   callRuntimeCallbacks(__ATPRERUN__);
@@ -1254,10 +1406,11 @@ function exitRuntime() {
 
 function postRun() {
   // compatibility - merge in anything from Module['postRun'] at this time
-  if (Module['postRun']) {
-    if (typeof Module['postRun'] == 'function') Module['postRun'] = [Module['postRun']];
-    while (Module['postRun'].length) {
-      addOnPostRun(Module['postRun'].shift());
+  if (Module["postRun"]) {
+    if (typeof Module["postRun"] == "function")
+      Module["postRun"] = [Module["postRun"]];
+    while (Module["postRun"].length) {
+      addOnPostRun(Module["postRun"].shift());
     }
   }
   callRuntimeCallbacks(__ATPOSTRUN__);
@@ -1290,9 +1443,8 @@ Module["addOnPostRun"] = addOnPostRun;
 
 // Tools
 
-
 function intArrayFromString(stringy, dontAddNull, length /* optional */) {
-  var len = length > 0 ? length : lengthBytesUTF8(stringy)+1;
+  var len = length > 0 ? length : lengthBytesUTF8(stringy) + 1;
   var u8array = new Array(len);
   var numBytesWritten = stringToUTF8Array(stringy, u8array, 0, u8array.length);
   if (dontAddNull) u8array.length = numBytesWritten;
@@ -1304,12 +1456,12 @@ function intArrayToString(array) {
   var ret = [];
   for (var i = 0; i < array.length; i++) {
     var chr = array[i];
-    if (chr > 0xFF) {
-      chr &= 0xFF;
+    if (chr > 0xff) {
+      chr &= 0xff;
     }
     ret.push(String.fromCharCode(chr));
   }
-  return ret.join('');
+  return ret.join("");
 }
 Module["intArrayToString"] = intArrayToString;
 
@@ -1318,7 +1470,9 @@ Module["intArrayToString"] = intArrayToString;
 // function stringToUTF8Array() instead, which takes in a maximum length that can be used
 // to be secure from out of bounds writes.
 function writeStringToMemory(string, buffer, dontAddNull) {
-  Runtime.warnOnce('writeStringToMemory is deprecated and should not be called! Use stringToUTF8() instead!');
+  Runtime.warnOnce(
+    "writeStringToMemory is deprecated and should not be called! Use stringToUTF8() instead!",
+  );
 
   var lastChar, end;
   if (dontAddNull) {
@@ -1340,10 +1494,10 @@ Module["writeArrayToMemory"] = writeArrayToMemory;
 
 function writeAsciiToMemory(str, buffer, dontAddNull) {
   for (var i = 0; i < str.length; ++i) {
-    HEAP8[((buffer++)>>0)]=str.charCodeAt(i);
+    HEAP8[buffer++ >> 0] = str.charCodeAt(i);
   }
   // Null-terminate the pointer to the HEAP.
-  if (!dontAddNull) HEAP8[((buffer)>>0)]=0;
+  if (!dontAddNull) HEAP8[buffer >> 0] = 0;
 }
 Module["writeAsciiToMemory"] = writeAsciiToMemory;
 
@@ -1351,53 +1505,62 @@ function unSign(value, bits, ignore) {
   if (value >= 0) {
     return value;
   }
-  return bits <= 32 ? 2*Math.abs(1 << (bits-1)) + value // Need some trickery, since if bits == 32, we are right at the limit of the bits JS uses in bitshifts
-                    : Math.pow(2, bits)         + value;
+  return bits <= 32
+    ? 2 * Math.abs(1 << (bits - 1)) + value // Need some trickery, since if bits == 32, we are right at the limit of the bits JS uses in bitshifts
+    : Math.pow(2, bits) + value;
 }
 function reSign(value, bits, ignore) {
   if (value <= 0) {
     return value;
   }
-  var half = bits <= 32 ? Math.abs(1 << (bits-1)) // abs is needed if bits == 32
-                        : Math.pow(2, bits-1);
-  if (value >= half && (bits <= 32 || value > half)) { // for huge values, we can hit the precision limit and always get true here. so don't do that
-                                                       // but, in general there is no perfect solution here. With 64-bit ints, we get rounding and errors
-                                                       // TODO: In i64 mode 1, resign the two parts separately and safely
-    value = -2*half + value; // Cannot bitshift half, as it may be at the limit of the bits JS uses in bitshifts
+  var half =
+    bits <= 32
+      ? Math.abs(1 << (bits - 1)) // abs is needed if bits == 32
+      : Math.pow(2, bits - 1);
+  if (value >= half && (bits <= 32 || value > half)) {
+    // for huge values, we can hit the precision limit and always get true here. so don't do that
+    // but, in general there is no perfect solution here. With 64-bit ints, we get rounding and errors
+    // TODO: In i64 mode 1, resign the two parts separately and safely
+    value = -2 * half + value; // Cannot bitshift half, as it may be at the limit of the bits JS uses in bitshifts
   }
   return value;
 }
 
-
 // check for imul support, and also for correctness ( https://bugs.webkit.org/show_bug.cgi?id=126345 )
-if (!Math['imul'] || Math['imul'](0xffffffff, 5) !== -5) Math['imul'] = function imul(a, b) {
-  var ah  = a >>> 16;
-  var al = a & 0xffff;
-  var bh  = b >>> 16;
-  var bl = b & 0xffff;
-  return (al*bl + ((ah*bl + al*bh) << 16))|0;
-};
-Math.imul = Math['imul'];
+if (!Math["imul"] || Math["imul"](0xffffffff, 5) !== -5)
+  Math["imul"] = function imul(a, b) {
+    var ah = a >>> 16;
+    var al = a & 0xffff;
+    var bh = b >>> 16;
+    var bl = b & 0xffff;
+    return (al * bl + ((ah * bl + al * bh) << 16)) | 0;
+  };
+Math.imul = Math["imul"];
 
-if (!Math['fround']) {
+if (!Math["fround"]) {
   var froundBuffer = new Float32Array(1);
-  Math['fround'] = function(x) { froundBuffer[0] = x; return froundBuffer[0] };
+  Math["fround"] = function (x) {
+    froundBuffer[0] = x;
+    return froundBuffer[0];
+  };
 }
-Math.fround = Math['fround'];
+Math.fround = Math["fround"];
 
-if (!Math['clz32']) Math['clz32'] = function(x) {
-  x = x >>> 0;
-  for (var i = 0; i < 32; i++) {
-    if (x & (1 << (31 - i))) return i;
-  }
-  return 32;
-};
-Math.clz32 = Math['clz32']
+if (!Math["clz32"])
+  Math["clz32"] = function (x) {
+    x = x >>> 0;
+    for (var i = 0; i < 32; i++) {
+      if (x & (1 << (31 - i))) return i;
+    }
+    return 32;
+  };
+Math.clz32 = Math["clz32"];
 
-if (!Math['trunc']) Math['trunc'] = function(x) {
-  return x < 0 ? Math.ceil(x) : Math.floor(x);
-};
-Math.trunc = Math['trunc'];
+if (!Math["trunc"])
+  Math["trunc"] = function (x) {
+    return x < 0 ? Math.ceil(x) : Math.floor(x);
+  };
+Math.trunc = Math["trunc"];
 
 var Math_abs = Math.abs;
 var Math_cos = Math.cos;
@@ -1437,16 +1600,16 @@ function getUniqueRunDependency(id) {
 
 function addRunDependency(id) {
   runDependencies++;
-  if (Module['monitorRunDependencies']) {
-    Module['monitorRunDependencies'](runDependencies);
+  if (Module["monitorRunDependencies"]) {
+    Module["monitorRunDependencies"](runDependencies);
   }
 }
 Module["addRunDependency"] = addRunDependency;
 
 function removeRunDependency(id) {
   runDependencies--;
-  if (Module['monitorRunDependencies']) {
-    Module['monitorRunDependencies'](runDependencies);
+  if (Module["monitorRunDependencies"]) {
+    Module["monitorRunDependencies"](runDependencies);
   }
   if (runDependencies == 0) {
     if (runDependencyWatcher !== null) {
@@ -1465,13 +1628,7 @@ Module["removeRunDependency"] = removeRunDependency;
 Module["preloadedImages"] = {}; // maps url to image data
 Module["preloadedAudios"] = {}; // maps url to audio data
 
-
-
 var memoryInitializer = null;
-
-
-
-
 
 function integrateWasmJS(Module) {
   // wasm.js has several methods for creating the compiled code module here:
@@ -1487,56 +1644,57 @@ function integrateWasmJS(Module) {
 
   // inputs
 
-  var method = Module['wasmJSMethod'] || 'native-wasm';
-  Module['wasmJSMethod'] = method;
+  var method = Module["wasmJSMethod"] || "native-wasm";
+  Module["wasmJSMethod"] = method;
 
-  var wasmTextFile = Module['wasmTextFile'] || 'change.wast';
-  var wasmBinaryFile = Module['wasmBinaryFile'] || 'change.wasm';
-  var asmjsCodeFile = Module['asmjsCodeFile'] || 'change.temp.asm.js';
+  var wasmTextFile = Module["wasmTextFile"] || "change.wast";
+  var wasmBinaryFile = Module["wasmBinaryFile"] || "change.wasm";
+  var asmjsCodeFile = Module["asmjsCodeFile"] || "change.temp.asm.js";
 
   // utilities
 
-  var wasmPageSize = 64*1024;
+  var wasmPageSize = 64 * 1024;
 
-  var asm2wasmImports = { // special asm2wasm imports
-    "f64-rem": function(x, y) {
+  var asm2wasmImports = {
+    // special asm2wasm imports
+    "f64-rem": function (x, y) {
       return x % y;
     },
-    "f64-to-int": function(x) {
+    "f64-to-int": function (x) {
       return x | 0;
     },
-    "i32s-div": function(x, y) {
+    "i32s-div": function (x, y) {
       return ((x | 0) / (y | 0)) | 0;
     },
-    "i32u-div": function(x, y) {
+    "i32u-div": function (x, y) {
       return ((x >>> 0) / (y >>> 0)) >>> 0;
     },
-    "i32s-rem": function(x, y) {
+    "i32s-rem": function (x, y) {
       return ((x | 0) % (y | 0)) | 0;
     },
-    "i32u-rem": function(x, y) {
+    "i32u-rem": function (x, y) {
       return ((x >>> 0) % (y >>> 0)) >>> 0;
     },
-    "debugger": function() {
+    debugger: function () {
       debugger;
     },
   };
 
   var info = {
-    'global': null,
-    'env': null,
-    'asm2wasm': asm2wasmImports,
-    'parent': Module // Module inside wasm-js.cpp refers to wasm-js.cpp; this allows access to the outside program.
+    global: null,
+    env: null,
+    asm2wasm: asm2wasmImports,
+    parent: Module, // Module inside wasm-js.cpp refers to wasm-js.cpp; this allows access to the outside program.
   };
 
   var exports = null;
 
   function lookupImport(mod, base) {
     var lookup = info;
-    if (mod.indexOf('.') < 0) {
+    if (mod.indexOf(".") < 0) {
       lookup = (lookup || {})[mod];
     } else {
-      var parts = mod.split('.');
+      var parts = mod.split(".");
       lookup = (lookup || {})[parts[0]];
       lookup = (lookup || {})[parts[1]];
     }
@@ -1544,7 +1702,7 @@ function integrateWasmJS(Module) {
       lookup = (lookup || {})[base];
     }
     if (lookup === undefined) {
-      abort('bad lookupImport to (' + mod + ').' + base);
+      abort("bad lookupImport to (" + mod + ")." + base);
     }
     return lookup;
   }
@@ -1554,16 +1712,24 @@ function integrateWasmJS(Module) {
     // buffer already, including the mem init file, and we must copy it over in a proper merge.
     // TODO: avoid this copy, by avoiding such static init writes
     // TODO: in shorter term, just copy up to the last static init write
-    var oldBuffer = Module['buffer'];
+    var oldBuffer = Module["buffer"];
     if (newBuffer.byteLength < oldBuffer.byteLength) {
-      Module['printErr']('the new buffer in mergeMemory is smaller than the previous one. in native wasm, we should grow memory here');
+      Module["printErr"](
+        "the new buffer in mergeMemory is smaller than the previous one. in native wasm, we should grow memory here",
+      );
     }
     var oldView = new Int8Array(oldBuffer);
     var newView = new Int8Array(newBuffer);
 
     // If we have a mem init file, do not trample it
     if (!memoryInitializer) {
-      oldView.set(newView.subarray(Module['STATIC_BASE'], Module['STATIC_BASE'] + Module['STATIC_BUMP']), Module['STATIC_BASE']);
+      oldView.set(
+        newView.subarray(
+          Module["STATIC_BASE"],
+          Module["STATIC_BASE"] + Module["STATIC_BUMP"],
+        ),
+        Module["STATIC_BASE"],
+      );
     }
 
     newView.set(oldView);
@@ -1576,7 +1742,7 @@ function integrateWasmJS(Module) {
     i32: 1,
     i64: 2,
     f32: 3,
-    f64: 4
+    f64: 4,
   };
 
   function fixImports(imports) {
@@ -1584,7 +1750,7 @@ function integrateWasmJS(Module) {
     var ret = {};
     for (var i in imports) {
       var fixed = i;
-      if (fixed[0] == '_') fixed = fixed.substr(1);
+      if (fixed[0] == "_") fixed = fixed.substr(1);
       ret[fixed] = imports[i];
     }
     return ret;
@@ -1593,11 +1759,14 @@ function integrateWasmJS(Module) {
   function getBinary() {
     var binary;
     if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
-      binary = Module['wasmBinary'];
-      assert(binary, "on the web, we need the wasm binary to be preloaded and set on Module['wasmBinary']. emcc.py will do that for you when generating HTML (but not JS)");
+      binary = Module["wasmBinary"];
+      assert(
+        binary,
+        "on the web, we need the wasm binary to be preloaded and set on Module['wasmBinary']. emcc.py will do that for you when generating HTML (but not JS)",
+      );
       binary = new Uint8Array(binary);
     } else {
-      binary = Module['readBinary'](wasmBinaryFile);
+      binary = Module["readBinary"](wasmBinaryFile);
     }
     return binary;
   }
@@ -1607,64 +1776,76 @@ function integrateWasmJS(Module) {
   function doJustAsm(global, env, providedBuffer) {
     // if no Module.asm, or it's the method handler helper (see below), then apply
     // the asmjs
-    if (typeof Module['asm'] !== 'function' || Module['asm'] === methodHandler) {
-      if (!Module['asmPreload']) {
+    if (
+      typeof Module["asm"] !== "function" ||
+      Module["asm"] === methodHandler
+    ) {
+      if (!Module["asmPreload"]) {
         // you can load the .asm.js file before this, to avoid this sync xhr and eval
-        eval(Module['read'](asmjsCodeFile)); // set Module.asm
+        eval(Module["read"](asmjsCodeFile)); // set Module.asm
       } else {
-        Module['asm'] = Module['asmPreload'];
+        Module["asm"] = Module["asmPreload"];
       }
     }
-    if (typeof Module['asm'] !== 'function') {
-      Module['printErr']('asm evalling did not set the module properly');
+    if (typeof Module["asm"] !== "function") {
+      Module["printErr"]("asm evalling did not set the module properly");
       return false;
     }
-    return Module['asm'](global, env, providedBuffer);
+    return Module["asm"](global, env, providedBuffer);
   }
 
   function doNativeWasm(global, env, providedBuffer) {
-    if (typeof WebAssembly !== 'object') {
-      Module['printErr']('no native wasm support detected');
+    if (typeof WebAssembly !== "object") {
+      Module["printErr"]("no native wasm support detected");
       return false;
     }
     // prepare memory import
-    if (!(Module['wasmMemory'] instanceof WebAssembly.Memory)) {
-      Module['printErr']('no native wasm Memory in use');
+    if (!(Module["wasmMemory"] instanceof WebAssembly.Memory)) {
+      Module["printErr"]("no native wasm Memory in use");
       return false;
     }
-    env['memory'] = Module['wasmMemory'];
+    env["memory"] = Module["wasmMemory"];
     // Load the wasm module and create an instance of using native support in the JS engine.
-    info['global'] = {
-      'NaN': NaN,
-      'Infinity': Infinity
+    info["global"] = {
+      NaN: NaN,
+      Infinity: Infinity,
     };
-    info['global.Math'] = global.Math;
-    info['env'] = env;
+    info["global.Math"] = global.Math;
+    info["env"] = env;
     // handle a generated wasm instance, receiving its exports and
     // performing other necessary setup
     function receiveInstance(instance) {
       exports = instance.exports;
       if (exports.memory) mergeMemory(exports.memory);
-      Module['asm'] = exports;
+      Module["asm"] = exports;
       Module["usingWasm"] = true;
     }
-    Module['printErr']('asynchronously preparing wasm');
-    addRunDependency('wasm-instantiate'); // we can't run yet
-    WebAssembly.instantiate(getBinary(), info).then(function(output) {
-      // receiveInstance() will swap in the exports (to Module.asm) so they can be called
-      receiveInstance(output.instance);
-      removeRunDependency('wasm-instantiate');
-    }).catch(function(reason) {
-      Module['printErr']('failed to asynchronously prepare wasm:\n  ' + reason);
-    });
+    Module["printErr"]("asynchronously preparing wasm");
+    addRunDependency("wasm-instantiate"); // we can't run yet
+    WebAssembly.instantiate(getBinary(), info)
+      .then(function (output) {
+        // receiveInstance() will swap in the exports (to Module.asm) so they can be called
+        receiveInstance(output.instance);
+        removeRunDependency("wasm-instantiate");
+      })
+      .catch(function (reason) {
+        Module["printErr"](
+          "failed to asynchronously prepare wasm:\n  " + reason,
+        );
+      });
     return {}; // no exports yet; we'll fill them in later
     var instance;
     try {
-      instance = new WebAssembly.Instance(new WebAssembly.Module(getBinary()), info)
+      instance = new WebAssembly.Instance(
+        new WebAssembly.Module(getBinary()),
+        info,
+      );
     } catch (e) {
-      Module['printErr']('failed to compile wasm module: ' + e);
-      if (e.toString().indexOf('imported Memory with incompatible size') >= 0) {
-        Module['printErr']('Memory size incompatibility issues may be due to changing TOTAL_MEMORY at runtime to something too large. Use ALLOW_MEMORY_GROWTH to allow any size memory (and also make sure not to set TOTAL_MEMORY at runtime to something smaller than it was at compile time).');
+      Module["printErr"]("failed to compile wasm module: " + e);
+      if (e.toString().indexOf("imported Memory with incompatible size") >= 0) {
+        Module["printErr"](
+          "Memory size incompatibility issues may be due to changing TOTAL_MEMORY at runtime to something too large. Use ALLOW_MEMORY_GROWTH to allow any size memory (and also make sure not to set TOTAL_MEMORY at runtime to something smaller than it was at compile time).",
+        );
       }
       return false;
     }
@@ -1673,8 +1854,8 @@ function integrateWasmJS(Module) {
   }
 
   function doWasmPolyfill(global, env, providedBuffer, method) {
-    if (typeof WasmJS !== 'function') {
-      Module['printErr']('WasmJS not detected - polyfill not bundled?');
+    if (typeof WasmJS !== "function") {
+      Module["printErr"]("WasmJS not detected - polyfill not bundled?");
       return false;
     }
 
@@ -1682,86 +1863,88 @@ function integrateWasmJS(Module) {
     var wasmJS = WasmJS({});
 
     // XXX don't be confused. Module here is in the outside program. wasmJS is the inner wasm-js.cpp.
-    wasmJS['outside'] = Module; // Inside wasm-js.cpp, Module['outside'] reaches the outside module.
+    wasmJS["outside"] = Module; // Inside wasm-js.cpp, Module['outside'] reaches the outside module.
 
     // Information for the instance of the module.
-    wasmJS['info'] = info;
+    wasmJS["info"] = info;
 
-    wasmJS['lookupImport'] = lookupImport;
+    wasmJS["lookupImport"] = lookupImport;
 
-    assert(providedBuffer === Module['buffer']); // we should not even need to pass it as a 3rd arg for wasm, but that's the asm.js way.
+    assert(providedBuffer === Module["buffer"]); // we should not even need to pass it as a 3rd arg for wasm, but that's the asm.js way.
 
     info.global = global;
     info.env = env;
 
     // polyfill interpreter expects an ArrayBuffer
-    assert(providedBuffer === Module['buffer']);
-    env['memory'] = providedBuffer;
-    assert(env['memory'] instanceof ArrayBuffer);
+    assert(providedBuffer === Module["buffer"]);
+    env["memory"] = providedBuffer;
+    assert(env["memory"] instanceof ArrayBuffer);
 
-    wasmJS['providedTotalMemory'] = Module['buffer'].byteLength;
+    wasmJS["providedTotalMemory"] = Module["buffer"].byteLength;
 
     // Prepare to generate wasm, using either asm2wasm or s-exprs
     var code;
-    if (method === 'interpret-binary') {
+    if (method === "interpret-binary") {
       code = getBinary();
     } else {
-      code = Module['read'](method == 'interpret-asm2wasm' ? asmjsCodeFile : wasmTextFile);
+      code = Module["read"](
+        method == "interpret-asm2wasm" ? asmjsCodeFile : wasmTextFile,
+      );
     }
     var temp;
-    if (method == 'interpret-asm2wasm') {
-      temp = wasmJS['_malloc'](code.length + 1);
-      wasmJS['writeAsciiToMemory'](code, temp);
-      wasmJS['_load_asm2wasm'](temp);
-    } else if (method === 'interpret-s-expr') {
-      temp = wasmJS['_malloc'](code.length + 1);
-      wasmJS['writeAsciiToMemory'](code, temp);
-      wasmJS['_load_s_expr2wasm'](temp);
-    } else if (method === 'interpret-binary') {
-      temp = wasmJS['_malloc'](code.length);
-      wasmJS['HEAPU8'].set(code, temp);
-      wasmJS['_load_binary2wasm'](temp, code.length);
+    if (method == "interpret-asm2wasm") {
+      temp = wasmJS["_malloc"](code.length + 1);
+      wasmJS["writeAsciiToMemory"](code, temp);
+      wasmJS["_load_asm2wasm"](temp);
+    } else if (method === "interpret-s-expr") {
+      temp = wasmJS["_malloc"](code.length + 1);
+      wasmJS["writeAsciiToMemory"](code, temp);
+      wasmJS["_load_s_expr2wasm"](temp);
+    } else if (method === "interpret-binary") {
+      temp = wasmJS["_malloc"](code.length);
+      wasmJS["HEAPU8"].set(code, temp);
+      wasmJS["_load_binary2wasm"](temp, code.length);
     } else {
-      throw 'what? ' + method;
+      throw "what? " + method;
     }
-    wasmJS['_free'](temp);
+    wasmJS["_free"](temp);
 
-    wasmJS['_instantiate'](temp);
+    wasmJS["_instantiate"](temp);
 
-    if (Module['newBuffer']) {
-      mergeMemory(Module['newBuffer']);
-      Module['newBuffer'] = null;
+    if (Module["newBuffer"]) {
+      mergeMemory(Module["newBuffer"]);
+      Module["newBuffer"] = null;
     }
 
-    exports = wasmJS['asmExports'];
+    exports = wasmJS["asmExports"];
 
     return exports;
   }
 
   // We may have a preloaded value in Module.asm, save it
-  Module['asmPreload'] = Module['asm'];
+  Module["asmPreload"] = Module["asm"];
 
   // Memory growth integration code
-  Module['reallocBuffer'] = function(size) {
+  Module["reallocBuffer"] = function (size) {
     var PAGE_MULTIPLE = Module["usingWasm"] ? WASM_PAGE_SIZE : ASMJS_PAGE_SIZE; // In wasm, heap size must be a multiple of 64KB. In asm.js, they need to be multiples of 16MB.
     size = alignUp(size, PAGE_MULTIPLE); // round up to wasm page size
-    var old = Module['buffer'];
+    var old = Module["buffer"];
     var oldSize = old.byteLength;
     if (Module["usingWasm"]) {
       try {
-        var result = Module['wasmMemory'].grow((size - oldSize) / wasmPageSize); // .grow() takes a delta compared to the previous size
+        var result = Module["wasmMemory"].grow((size - oldSize) / wasmPageSize); // .grow() takes a delta compared to the previous size
         if (result !== (-1 | 0)) {
           // success in native wasm memory growth, get the buffer from the memory
-          return Module['buffer'] = Module['wasmMemory'].buffer;
+          return (Module["buffer"] = Module["wasmMemory"].buffer);
         } else {
           return null;
         }
-      } catch(e) {
+      } catch (e) {
         return null;
       }
     } else {
       // in interpreter, we replace Module.buffer if we allocate
-      return Module['buffer'] !== old ? Module['buffer'] : null; // if it was reallocated, it changed
+      return Module["buffer"] !== old ? Module["buffer"] : null; // if it was reallocated, it changed
     }
   };
 
@@ -1769,63 +1952,79 @@ function integrateWasmJS(Module) {
   // the wasm module at that time, and it receives imports and provides exports and so forth, the app
   // doesn't need to care that it is wasm or olyfilled wasm or asm.js.
 
-  Module['asm'] = function(global, env, providedBuffer) {
+  Module["asm"] = function (global, env, providedBuffer) {
     global = fixImports(global);
     env = fixImports(env);
 
     // import table
-    if (!env['table']) {
-      var TABLE_SIZE = Module['wasmTableSize'];
+    if (!env["table"]) {
+      var TABLE_SIZE = Module["wasmTableSize"];
       if (TABLE_SIZE === undefined) TABLE_SIZE = 1024; // works in binaryen interpreter at least
-      var MAX_TABLE_SIZE = Module['wasmMaxTableSize'];
-      if (typeof WebAssembly === 'object' && typeof WebAssembly.Table === 'function') {
+      var MAX_TABLE_SIZE = Module["wasmMaxTableSize"];
+      if (
+        typeof WebAssembly === "object" &&
+        typeof WebAssembly.Table === "function"
+      ) {
         if (MAX_TABLE_SIZE !== undefined) {
-          env['table'] = new WebAssembly.Table({ initial: TABLE_SIZE, maximum: MAX_TABLE_SIZE, element: 'anyfunc' });
+          env["table"] = new WebAssembly.Table({
+            initial: TABLE_SIZE,
+            maximum: MAX_TABLE_SIZE,
+            element: "funcref",
+          });
         } else {
-          env['table'] = new WebAssembly.Table({ initial: TABLE_SIZE, element: 'anyfunc' });
+          env["table"] = new WebAssembly.Table({
+            initial: TABLE_SIZE,
+            element: "funcref",
+          });
         }
       } else {
-        env['table'] = new Array(TABLE_SIZE); // works in binaryen interpreter at least
+        env["table"] = new Array(TABLE_SIZE); // works in binaryen interpreter at least
       }
-      Module['wasmTable'] = env['table'];
+      Module["wasmTable"] = env["table"];
     }
 
-    if (!env['memoryBase']) {
-      env['memoryBase'] = Module['STATIC_BASE']; // tell the memory segments where to place themselves
+    if (!env["memoryBase"]) {
+      env["memoryBase"] = Module["STATIC_BASE"]; // tell the memory segments where to place themselves
     }
-    if (!env['tableBase']) {
-      env['tableBase'] = 0; // table starts at 0 by default, in dynamic linking this will change
+    if (!env["tableBase"]) {
+      env["tableBase"] = 0; // table starts at 0 by default, in dynamic linking this will change
     }
 
     // try the methods. each should return the exports if it succeeded
 
     var exports;
-    var methods = method.split(',');
+    var methods = method.split(",");
 
     for (var i = 0; i < methods.length; i++) {
       var curr = methods[i];
 
-      Module['printErr']('trying binaryen method: ' + curr);
+      Module["printErr"]("trying binaryen method: " + curr);
 
-      if (curr === 'native-wasm') {
-        if (exports = doNativeWasm(global, env, providedBuffer)) break;
-      } else if (curr === 'asmjs') {
-        if (exports = doJustAsm(global, env, providedBuffer)) break;
-      } else if (curr === 'interpret-asm2wasm' || curr === 'interpret-s-expr' || curr === 'interpret-binary') {
-        if (exports = doWasmPolyfill(global, env, providedBuffer, curr)) break;
+      if (curr === "native-wasm") {
+        if ((exports = doNativeWasm(global, env, providedBuffer))) break;
+      } else if (curr === "asmjs") {
+        if ((exports = doJustAsm(global, env, providedBuffer))) break;
+      } else if (
+        curr === "interpret-asm2wasm" ||
+        curr === "interpret-s-expr" ||
+        curr === "interpret-binary"
+      ) {
+        if ((exports = doWasmPolyfill(global, env, providedBuffer, curr)))
+          break;
       } else {
-        throw 'bad method: ' + curr;
+        throw "bad method: " + curr;
       }
     }
 
-    if (!exports) throw 'no binaryen method succeeded. consider enabling more options, like interpreting, if you want that: https://github.com/kripken/emscripten/wiki/WebAssembly#binaryen-methods';
+    if (!exports)
+      throw "no binaryen method succeeded. consider enabling more options, like interpreting, if you want that: https://github.com/kripken/emscripten/wiki/WebAssembly#binaryen-methods";
 
-    Module['printErr']('binaryen method succeeded.');
+    Module["printErr"]("binaryen method succeeded.");
 
     return exports;
   };
 
-  var methodHandler = Module['asm']; // note our method handler, as we may modify Module['asm'] later
+  var methodHandler = Module["asm"]; // note our method handler, as we may modify Module['asm'] later
 }
 
 integrateWasmJS(Module);
@@ -1834,188 +2033,214 @@ integrateWasmJS(Module);
 
 var ASM_CONSTS = [];
 
-
-
-
 STATIC_BASE = 1024;
 
 STATICTOP = STATIC_BASE + 1154720;
-  /* global initializers */  __ATINIT__.push();
-  
+/* global initializers */ __ATINIT__.push();
 
-memoryInitializer = Module["wasmJSMethod"].indexOf("asmjs") >= 0 || Module["wasmJSMethod"].indexOf("interpret-asm2wasm") >= 0 ? "change.js.mem" : null;
-
-
-
+memoryInitializer =
+  Module["wasmJSMethod"].indexOf("asmjs") >= 0 ||
+  Module["wasmJSMethod"].indexOf("interpret-asm2wasm") >= 0
+    ? "change.js.mem"
+    : null;
 
 var STATIC_BUMP = 1154720;
 Module["STATIC_BASE"] = STATIC_BASE;
 Module["STATIC_BUMP"] = STATIC_BUMP;
 
 /* no memory initializer */
-var tempDoublePtr = STATICTOP; STATICTOP += 16;
+var tempDoublePtr = STATICTOP;
+STATICTOP += 16;
 
-function copyTempFloat(ptr) { // functions, because inlining this code increases code size too much
+function copyTempFloat(ptr) {
+  // functions, because inlining this code increases code size too much
 
   HEAP8[tempDoublePtr] = HEAP8[ptr];
 
-  HEAP8[tempDoublePtr+1] = HEAP8[ptr+1];
+  HEAP8[tempDoublePtr + 1] = HEAP8[ptr + 1];
 
-  HEAP8[tempDoublePtr+2] = HEAP8[ptr+2];
+  HEAP8[tempDoublePtr + 2] = HEAP8[ptr + 2];
 
-  HEAP8[tempDoublePtr+3] = HEAP8[ptr+3];
-
+  HEAP8[tempDoublePtr + 3] = HEAP8[ptr + 3];
 }
 
 function copyTempDouble(ptr) {
-
   HEAP8[tempDoublePtr] = HEAP8[ptr];
 
-  HEAP8[tempDoublePtr+1] = HEAP8[ptr+1];
+  HEAP8[tempDoublePtr + 1] = HEAP8[ptr + 1];
 
-  HEAP8[tempDoublePtr+2] = HEAP8[ptr+2];
+  HEAP8[tempDoublePtr + 2] = HEAP8[ptr + 2];
 
-  HEAP8[tempDoublePtr+3] = HEAP8[ptr+3];
+  HEAP8[tempDoublePtr + 3] = HEAP8[ptr + 3];
 
-  HEAP8[tempDoublePtr+4] = HEAP8[ptr+4];
+  HEAP8[tempDoublePtr + 4] = HEAP8[ptr + 4];
 
-  HEAP8[tempDoublePtr+5] = HEAP8[ptr+5];
+  HEAP8[tempDoublePtr + 5] = HEAP8[ptr + 5];
 
-  HEAP8[tempDoublePtr+6] = HEAP8[ptr+6];
+  HEAP8[tempDoublePtr + 6] = HEAP8[ptr + 6];
 
-  HEAP8[tempDoublePtr+7] = HEAP8[ptr+7];
-
+  HEAP8[tempDoublePtr + 7] = HEAP8[ptr + 7];
 }
 
 // {{PRE_LIBRARY}}
 
+function ___setErrNo(value) {
+  if (Module["___errno_location"])
+    HEAP32[Module["___errno_location"]() >> 2] = value;
+  return value;
+}
+Module["_sbrk"] = _sbrk;
 
-  
-  function ___setErrNo(value) {
-      if (Module['___errno_location']) HEAP32[((Module['___errno_location']())>>2)]=value;
-      return value;
-    } 
-  Module["_sbrk"] = _sbrk;
+Module["_memset"] = _memset;
 
-   
-  Module["_memset"] = _memset;
+function _pthread_cleanup_push(routine, arg) {
+  __ATEXIT__.push(function () {
+    Module["dynCall_vi"](routine, arg);
+  });
+  _pthread_cleanup_push.level = __ATEXIT__.length;
+}
 
-  function _pthread_cleanup_push(routine, arg) {
-      __ATEXIT__.push(function() { Module['dynCall_vi'](routine, arg) })
-      _pthread_cleanup_push.level = __ATEXIT__.length;
-    }
+function ___lock() {}
 
-  function ___lock() {}
+function _emscripten_memcpy_big(dest, src, num) {
+  HEAPU8.set(HEAPU8.subarray(src, src + num), dest);
+  return dest;
+}
+Module["_memcpy"] = _memcpy;
 
-  
-  function _emscripten_memcpy_big(dest, src, num) {
-      HEAPU8.set(HEAPU8.subarray(src, src+num), dest);
-      return dest;
-    } 
-  Module["_memcpy"] = _memcpy;
+function _pthread_cleanup_pop() {
+  assert(
+    _pthread_cleanup_push.level == __ATEXIT__.length,
+    "cannot pop if something else added meanwhile!",
+  );
+  __ATEXIT__.pop();
+  _pthread_cleanup_push.level = __ATEXIT__.length;
+}
 
-  function _pthread_cleanup_pop() {
-      assert(_pthread_cleanup_push.level == __ATEXIT__.length, 'cannot pop if something else added meanwhile!');
-      __ATEXIT__.pop();
-      _pthread_cleanup_push.level = __ATEXIT__.length;
-    }
+function _abort() {
+  Module["abort"]();
+}
 
-  function _abort() {
-      Module['abort']();
-    }
+Module["_pthread_self"] = _pthread_self;
 
-   
-  Module["_pthread_self"] = _pthread_self;
-
-  
-  var SYSCALLS={varargs:0,get:function (varargs) {
-        SYSCALLS.varargs += 4;
-        var ret = HEAP32[(((SYSCALLS.varargs)-(4))>>2)];
-        return ret;
-      },getStr:function () {
-        var ret = Pointer_stringify(SYSCALLS.get());
-        return ret;
-      },get64:function () {
-        var low = SYSCALLS.get(), high = SYSCALLS.get();
-        if (low >= 0) assert(high === 0);
-        else assert(high === -1);
-        return low;
-      },getZero:function () {
-        assert(SYSCALLS.get() === 0);
-      }};function ___syscall140(which, varargs) {SYSCALLS.varargs = varargs;
+var SYSCALLS = {
+  varargs: 0,
+  get: function (varargs) {
+    SYSCALLS.varargs += 4;
+    var ret = HEAP32[(SYSCALLS.varargs - 4) >> 2];
+    return ret;
+  },
+  getStr: function () {
+    var ret = Pointer_stringify(SYSCALLS.get());
+    return ret;
+  },
+  get64: function () {
+    var low = SYSCALLS.get(),
+      high = SYSCALLS.get();
+    if (low >= 0) assert(high === 0);
+    else assert(high === -1);
+    return low;
+  },
+  getZero: function () {
+    assert(SYSCALLS.get() === 0);
+  },
+};
+function ___syscall140(which, varargs) {
+  SYSCALLS.varargs = varargs;
   try {
-   // llseek
-      var stream = SYSCALLS.getStreamFromFD(), offset_high = SYSCALLS.get(), offset_low = SYSCALLS.get(), result = SYSCALLS.get(), whence = SYSCALLS.get();
-      var offset = offset_low;
-      assert(offset_high === 0);
-      FS.llseek(stream, offset, whence);
-      HEAP32[((result)>>2)]=stream.position;
-      if (stream.getdents && offset === 0 && whence === 0) stream.getdents = null; // reset readdir state
-      return 0;
-    } catch (e) {
-    if (typeof FS === 'undefined' || !(e instanceof FS.ErrnoError)) abort(e);
+    // llseek
+    var stream = SYSCALLS.getStreamFromFD(),
+      offset_high = SYSCALLS.get(),
+      offset_low = SYSCALLS.get(),
+      result = SYSCALLS.get(),
+      whence = SYSCALLS.get();
+    var offset = offset_low;
+    assert(offset_high === 0);
+    FS.llseek(stream, offset, whence);
+    HEAP32[result >> 2] = stream.position;
+    if (stream.getdents && offset === 0 && whence === 0) stream.getdents = null; // reset readdir state
+    return 0;
+  } catch (e) {
+    if (typeof FS === "undefined" || !(e instanceof FS.ErrnoError)) abort(e);
     return -e.errno;
   }
-  }
+}
 
-  function ___syscall146(which, varargs) {SYSCALLS.varargs = varargs;
+function ___syscall146(which, varargs) {
+  SYSCALLS.varargs = varargs;
   try {
-   // writev
-      // hack to support printf in NO_FILESYSTEM
-      var stream = SYSCALLS.get(), iov = SYSCALLS.get(), iovcnt = SYSCALLS.get();
-      var ret = 0;
-      if (!___syscall146.buffer) {
-        ___syscall146.buffers = [null, [], []]; // 1 => stdout, 2 => stderr
-        ___syscall146.printChar = function(stream, curr) {
-          var buffer = ___syscall146.buffers[stream];
-          assert(buffer);
-          if (curr === 0 || curr === 10) {
-            (stream === 1 ? Module['print'] : Module['printErr'])(UTF8ArrayToString(buffer, 0));
-            buffer.length = 0;
-          } else {
-            buffer.push(curr);
-          }
-        };
-      }
-      for (var i = 0; i < iovcnt; i++) {
-        var ptr = HEAP32[(((iov)+(i*8))>>2)];
-        var len = HEAP32[(((iov)+(i*8 + 4))>>2)];
-        for (var j = 0; j < len; j++) {
-          ___syscall146.printChar(stream, HEAPU8[ptr+j]);
+    // writev
+    // hack to support printf in NO_FILESYSTEM
+    var stream = SYSCALLS.get(),
+      iov = SYSCALLS.get(),
+      iovcnt = SYSCALLS.get();
+    var ret = 0;
+    if (!___syscall146.buffer) {
+      ___syscall146.buffers = [null, [], []]; // 1 => stdout, 2 => stderr
+      ___syscall146.printChar = function (stream, curr) {
+        var buffer = ___syscall146.buffers[stream];
+        assert(buffer);
+        if (curr === 0 || curr === 10) {
+          (stream === 1 ? Module["print"] : Module["printErr"])(
+            UTF8ArrayToString(buffer, 0),
+          );
+          buffer.length = 0;
+        } else {
+          buffer.push(curr);
         }
-        ret += len;
+      };
+    }
+    for (var i = 0; i < iovcnt; i++) {
+      var ptr = HEAP32[(iov + i * 8) >> 2];
+      var len = HEAP32[(iov + (i * 8 + 4)) >> 2];
+      for (var j = 0; j < len; j++) {
+        ___syscall146.printChar(stream, HEAPU8[ptr + j]);
       }
-      return ret;
-    } catch (e) {
-    if (typeof FS === 'undefined' || !(e instanceof FS.ErrnoError)) abort(e);
+      ret += len;
+    }
+    return ret;
+  } catch (e) {
+    if (typeof FS === "undefined" || !(e instanceof FS.ErrnoError)) abort(e);
     return -e.errno;
   }
-  }
+}
 
-  function ___syscall54(which, varargs) {SYSCALLS.varargs = varargs;
+function ___syscall54(which, varargs) {
+  SYSCALLS.varargs = varargs;
   try {
-   // ioctl
-      return 0;
-    } catch (e) {
-    if (typeof FS === 'undefined' || !(e instanceof FS.ErrnoError)) abort(e);
+    // ioctl
+    return 0;
+  } catch (e) {
+    if (typeof FS === "undefined" || !(e instanceof FS.ErrnoError)) abort(e);
     return -e.errno;
   }
-  }
+}
 
-  function ___unlock() {}
+function ___unlock() {}
 
-  function ___syscall6(which, varargs) {SYSCALLS.varargs = varargs;
+function ___syscall6(which, varargs) {
+  SYSCALLS.varargs = varargs;
   try {
-   // close
-      var stream = SYSCALLS.getStreamFromFD();
-      FS.close(stream);
-      return 0;
-    } catch (e) {
-    if (typeof FS === 'undefined' || !(e instanceof FS.ErrnoError)) abort(e);
+    // close
+    var stream = SYSCALLS.getStreamFromFD();
+    FS.close(stream);
+    return 0;
+  } catch (e) {
+    if (typeof FS === "undefined" || !(e instanceof FS.ErrnoError)) abort(e);
     return -e.errno;
   }
-  }
-/* flush anything remaining in the buffer during shutdown */ __ATEXIT__.push(function() { var fflush = Module["_fflush"]; if (fflush) fflush(0); var printChar = ___syscall146.printChar; if (!printChar) return; var buffers = ___syscall146.buffers; if (buffers[1].length) printChar(1, 10); if (buffers[2].length) printChar(2, 10); });;
+}
+/* flush anything remaining in the buffer during shutdown */ __ATEXIT__.push(
+  function () {
+    var fflush = Module["_fflush"];
+    if (fflush) fflush(0);
+    var printChar = ___syscall146.printChar;
+    if (!printChar) return;
+    var buffers = ___syscall146.buffers;
+    if (buffers[1].length) printChar(1, 10);
+    if (buffers[2].length) printChar(2, 10);
+  },
+);
 DYNAMICTOP_PTR = allocate(1, "i32", ALLOC_STATIC);
 
 STACK_BASE = STACKTOP = Runtime.alignMemory(STATICTOP);
@@ -2024,125 +2249,195 @@ STACK_MAX = STACK_BASE + TOTAL_STACK;
 
 DYNAMIC_BASE = Runtime.alignMemory(STACK_MAX);
 
-HEAP32[DYNAMICTOP_PTR>>2] = DYNAMIC_BASE;
+HEAP32[DYNAMICTOP_PTR >> 2] = DYNAMIC_BASE;
 
 staticSealed = true; // seal the static portion of memory
 
+Module["wasmTableSize"] = 8;
 
+Module["wasmMaxTableSize"] = 8;
 
-Module['wasmTableSize'] = 8;
-
-Module['wasmMaxTableSize'] = 8;
-
-function invoke_ii(index,a1) {
+function invoke_ii(index, a1) {
   try {
-    return Module["dynCall_ii"](index,a1);
-  } catch(e) {
-    if (typeof e !== 'number' && e !== 'longjmp') throw e;
+    return Module["dynCall_ii"](index, a1);
+  } catch (e) {
+    if (typeof e !== "number" && e !== "longjmp") throw e;
     asm["setThrew"](1, 0);
   }
 }
 
-function invoke_iiii(index,a1,a2,a3) {
+function invoke_iiii(index, a1, a2, a3) {
   try {
-    return Module["dynCall_iiii"](index,a1,a2,a3);
-  } catch(e) {
-    if (typeof e !== 'number' && e !== 'longjmp') throw e;
+    return Module["dynCall_iiii"](index, a1, a2, a3);
+  } catch (e) {
+    if (typeof e !== "number" && e !== "longjmp") throw e;
     asm["setThrew"](1, 0);
   }
 }
 
-function invoke_vi(index,a1) {
+function invoke_vi(index, a1) {
   try {
-    Module["dynCall_vi"](index,a1);
-  } catch(e) {
-    if (typeof e !== 'number' && e !== 'longjmp') throw e;
+    Module["dynCall_vi"](index, a1);
+  } catch (e) {
+    if (typeof e !== "number" && e !== "longjmp") throw e;
     asm["setThrew"](1, 0);
   }
 }
 
-Module.asmGlobalArg = { "Math": Math, "Int8Array": Int8Array, "Int16Array": Int16Array, "Int32Array": Int32Array, "Uint8Array": Uint8Array, "Uint16Array": Uint16Array, "Uint32Array": Uint32Array, "Float32Array": Float32Array, "Float64Array": Float64Array, "NaN": NaN, "Infinity": Infinity };
+Module.asmGlobalArg = {
+  Math: Math,
+  Int8Array: Int8Array,
+  Int16Array: Int16Array,
+  Int32Array: Int32Array,
+  Uint8Array: Uint8Array,
+  Uint16Array: Uint16Array,
+  Uint32Array: Uint32Array,
+  Float32Array: Float32Array,
+  Float64Array: Float64Array,
+  NaN: NaN,
+  Infinity: Infinity,
+};
 
-Module.asmLibraryArg = { "abort": abort, "assert": assert, "enlargeMemory": enlargeMemory, "getTotalMemory": getTotalMemory, "abortOnCannotGrowMemory": abortOnCannotGrowMemory, "invoke_ii": invoke_ii, "invoke_iiii": invoke_iiii, "invoke_vi": invoke_vi, "_pthread_cleanup_pop": _pthread_cleanup_pop, "___lock": ___lock, "_abort": _abort, "___setErrNo": ___setErrNo, "___syscall6": ___syscall6, "___syscall140": ___syscall140, "_pthread_cleanup_push": _pthread_cleanup_push, "_emscripten_memcpy_big": _emscripten_memcpy_big, "___syscall54": ___syscall54, "___unlock": ___unlock, "___syscall146": ___syscall146, "DYNAMICTOP_PTR": DYNAMICTOP_PTR, "tempDoublePtr": tempDoublePtr, "ABORT": ABORT, "STACKTOP": STACKTOP, "STACK_MAX": STACK_MAX };
+Module.asmLibraryArg = {
+  abort: abort,
+  assert: assert,
+  enlargeMemory: enlargeMemory,
+  getTotalMemory: getTotalMemory,
+  abortOnCannotGrowMemory: abortOnCannotGrowMemory,
+  invoke_ii: invoke_ii,
+  invoke_iiii: invoke_iiii,
+  invoke_vi: invoke_vi,
+  _pthread_cleanup_pop: _pthread_cleanup_pop,
+  ___lock: ___lock,
+  _abort: _abort,
+  ___setErrNo: ___setErrNo,
+  ___syscall6: ___syscall6,
+  ___syscall140: ___syscall140,
+  _pthread_cleanup_push: _pthread_cleanup_push,
+  _emscripten_memcpy_big: _emscripten_memcpy_big,
+  ___syscall54: ___syscall54,
+  ___unlock: ___unlock,
+  ___syscall146: ___syscall146,
+  DYNAMICTOP_PTR: DYNAMICTOP_PTR,
+  tempDoublePtr: tempDoublePtr,
+  ABORT: ABORT,
+  STACKTOP: STACKTOP,
+  STACK_MAX: STACK_MAX,
+};
 // EMSCRIPTEN_START_ASM
-var asm =Module["asm"]// EMSCRIPTEN_END_ASM
-(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+var asm = Module["asm"](
+  // EMSCRIPTEN_END_ASM
+  Module.asmGlobalArg,
+  Module.asmLibraryArg,
+  buffer,
+);
 
 Module["asm"] = asm;
-var _change = Module["_change"] = function() { return Module["asm"]["_change"].apply(null, arguments) };
-var _fflush = Module["_fflush"] = function() { return Module["asm"]["_fflush"].apply(null, arguments) };
-var runPostSets = Module["runPostSets"] = function() { return Module["asm"]["runPostSets"].apply(null, arguments) };
-var _pthread_self = Module["_pthread_self"] = function() { return Module["asm"]["_pthread_self"].apply(null, arguments) };
-var _memset = Module["_memset"] = function() { return Module["asm"]["_memset"].apply(null, arguments) };
-var _malloc = Module["_malloc"] = function() { return Module["asm"]["_malloc"].apply(null, arguments) };
-var _memcpy = Module["_memcpy"] = function() { return Module["asm"]["_memcpy"].apply(null, arguments) };
-var _sbrk = Module["_sbrk"] = function() { return Module["asm"]["_sbrk"].apply(null, arguments) };
-var _free = Module["_free"] = function() { return Module["asm"]["_free"].apply(null, arguments) };
-var ___errno_location = Module["___errno_location"] = function() { return Module["asm"]["___errno_location"].apply(null, arguments) };
-var dynCall_ii = Module["dynCall_ii"] = function() { return Module["asm"]["dynCall_ii"].apply(null, arguments) };
-var dynCall_iiii = Module["dynCall_iiii"] = function() { return Module["asm"]["dynCall_iiii"].apply(null, arguments) };
-var dynCall_vi = Module["dynCall_vi"] = function() { return Module["asm"]["dynCall_vi"].apply(null, arguments) };
-;
+var _change = (Module["_change"] = function () {
+  return Module["asm"]["_change"].apply(null, arguments);
+});
+var _fflush = (Module["_fflush"] = function () {
+  return Module["asm"]["_fflush"].apply(null, arguments);
+});
+var runPostSets = (Module["runPostSets"] = function () {
+  return Module["asm"]["runPostSets"].apply(null, arguments);
+});
+var _pthread_self = (Module["_pthread_self"] = function () {
+  return Module["asm"]["_pthread_self"].apply(null, arguments);
+});
+var _memset = (Module["_memset"] = function () {
+  return Module["asm"]["_memset"].apply(null, arguments);
+});
+var _malloc = (Module["_malloc"] = function () {
+  return Module["asm"]["_malloc"].apply(null, arguments);
+});
+var _memcpy = (Module["_memcpy"] = function () {
+  return Module["asm"]["_memcpy"].apply(null, arguments);
+});
+var _sbrk = (Module["_sbrk"] = function () {
+  return Module["asm"]["_sbrk"].apply(null, arguments);
+});
+var _free = (Module["_free"] = function () {
+  return Module["asm"]["_free"].apply(null, arguments);
+});
+var ___errno_location = (Module["___errno_location"] = function () {
+  return Module["asm"]["___errno_location"].apply(null, arguments);
+});
+var dynCall_ii = (Module["dynCall_ii"] = function () {
+  return Module["asm"]["dynCall_ii"].apply(null, arguments);
+});
+var dynCall_iiii = (Module["dynCall_iiii"] = function () {
+  return Module["asm"]["dynCall_iiii"].apply(null, arguments);
+});
+var dynCall_vi = (Module["dynCall_vi"] = function () {
+  return Module["asm"]["dynCall_vi"].apply(null, arguments);
+});
+Runtime.stackAlloc = asm["stackAlloc"];
+Runtime.stackSave = asm["stackSave"];
+Runtime.stackRestore = asm["stackRestore"];
+Runtime.establishStackSpace = asm["establishStackSpace"];
 
-Runtime.stackAlloc = asm['stackAlloc'];
-Runtime.stackSave = asm['stackSave'];
-Runtime.stackRestore = asm['stackRestore'];
-Runtime.establishStackSpace = asm['establishStackSpace'];
-
-Runtime.setTempRet0 = asm['setTempRet0'];
-Runtime.getTempRet0 = asm['getTempRet0'];
-
-
+Runtime.setTempRet0 = asm["setTempRet0"];
+Runtime.getTempRet0 = asm["getTempRet0"];
 
 // === Auto-generated postamble setup entry stuff ===
 
-Module['asm'] = asm;
-
-
+Module["asm"] = asm;
 
 if (memoryInitializer) {
-  if (typeof Module['locateFile'] === 'function') {
-    memoryInitializer = Module['locateFile'](memoryInitializer);
-  } else if (Module['memoryInitializerPrefixURL']) {
-    memoryInitializer = Module['memoryInitializerPrefixURL'] + memoryInitializer;
+  if (typeof Module["locateFile"] === "function") {
+    memoryInitializer = Module["locateFile"](memoryInitializer);
+  } else if (Module["memoryInitializerPrefixURL"]) {
+    memoryInitializer =
+      Module["memoryInitializerPrefixURL"] + memoryInitializer;
   }
   if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
-    var data = Module['readBinary'](memoryInitializer);
+    var data = Module["readBinary"](memoryInitializer);
     HEAPU8.set(data, Runtime.GLOBAL_BASE);
   } else {
-    addRunDependency('memory initializer');
-    var applyMemoryInitializer = function(data) {
+    addRunDependency("memory initializer");
+    var applyMemoryInitializer = function (data) {
       if (data.byteLength) data = new Uint8Array(data);
       HEAPU8.set(data, Runtime.GLOBAL_BASE);
       // Delete the typed array that contains the large blob of the memory initializer request response so that
       // we won't keep unnecessary memory lying around. However, keep the XHR object itself alive so that e.g.
       // its .status field can still be accessed later.
-      if (Module['memoryInitializerRequest']) delete Module['memoryInitializerRequest'].response;
-      removeRunDependency('memory initializer');
-    }
+      if (Module["memoryInitializerRequest"])
+        delete Module["memoryInitializerRequest"].response;
+      removeRunDependency("memory initializer");
+    };
     function doBrowserLoad() {
-      Module['readAsync'](memoryInitializer, applyMemoryInitializer, function() {
-        throw 'could not load memory initializer ' + memoryInitializer;
-      });
+      Module["readAsync"](
+        memoryInitializer,
+        applyMemoryInitializer,
+        function () {
+          throw "could not load memory initializer " + memoryInitializer;
+        },
+      );
     }
-    if (Module['memoryInitializerRequest']) {
+    if (Module["memoryInitializerRequest"]) {
       // a network request has already been created, just use that
       function useRequest() {
-        var request = Module['memoryInitializerRequest'];
+        var request = Module["memoryInitializerRequest"];
         if (request.status !== 200 && request.status !== 0) {
           // If you see this warning, the issue may be that you are using locateFile or memoryInitializerPrefixURL, and defining them in JS. That
           // means that the HTML file doesn't know about them, and when it tries to create the mem init request early, does it to the wrong place.
           // Look in your browser's devtools network console to see what's going on.
-          console.warn('a problem seems to have happened with Module.memoryInitializerRequest, status: ' + request.status + ', retrying ' + memoryInitializer);
+          console.warn(
+            "a problem seems to have happened with Module.memoryInitializerRequest, status: " +
+              request.status +
+              ", retrying " +
+              memoryInitializer,
+          );
           doBrowserLoad();
           return;
         }
         applyMemoryInitializer(request.response);
       }
-      if (Module['memoryInitializerRequest'].response) {
+      if (Module["memoryInitializerRequest"].response) {
         setTimeout(useRequest, 0); // it's already here; but, apply it asynchronously
       } else {
-        Module['memoryInitializerRequest'].addEventListener('load', useRequest); // wait for it
+        Module["memoryInitializerRequest"].addEventListener("load", useRequest); // wait for it
       }
     } else {
       // fetch it from the network ourselves
@@ -2151,12 +2446,11 @@ if (memoryInitializer) {
   }
 }
 
-
 function ExitStatus(status) {
   this.name = "ExitStatus";
   this.message = "Program terminated with exit(" + status + ")";
   this.status = status;
-};
+}
 ExitStatus.prototype = new Error();
 ExitStatus.prototype.constructor = ExitStatus;
 
@@ -2166,63 +2460,58 @@ var calledMain = false;
 
 dependenciesFulfilled = function runCaller() {
   // If run has never been called, and we should call run (INVOKE_RUN is true, and Module.noInitialRun is not false)
-  if (!Module['calledRun']) run();
-  if (!Module['calledRun']) dependenciesFulfilled = runCaller; // try this again later, after new deps are fulfilled
-}
+  if (!Module["calledRun"]) run();
+  if (!Module["calledRun"]) dependenciesFulfilled = runCaller; // try this again later, after new deps are fulfilled
+};
 
-Module['callMain'] = Module.callMain = function callMain(args) {
-
+Module["callMain"] = Module.callMain = function callMain(args) {
   args = args || [];
 
   ensureInitRuntime();
 
-  var argc = args.length+1;
+  var argc = args.length + 1;
   function pad() {
-    for (var i = 0; i < 4-1; i++) {
+    for (var i = 0; i < 4 - 1; i++) {
       argv.push(0);
     }
   }
-  var argv = [allocate(intArrayFromString(Module['thisProgram']), 'i8', ALLOC_NORMAL) ];
+  var argv = [
+    allocate(intArrayFromString(Module["thisProgram"]), "i8", ALLOC_NORMAL),
+  ];
   pad();
-  for (var i = 0; i < argc-1; i = i + 1) {
-    argv.push(allocate(intArrayFromString(args[i]), 'i8', ALLOC_NORMAL));
+  for (var i = 0; i < argc - 1; i = i + 1) {
+    argv.push(allocate(intArrayFromString(args[i]), "i8", ALLOC_NORMAL));
     pad();
   }
   argv.push(0);
-  argv = allocate(argv, 'i32', ALLOC_NORMAL);
-
+  argv = allocate(argv, "i32", ALLOC_NORMAL);
 
   try {
-
-    var ret = Module['_main'](argc, argv, 0);
-
+    var ret = Module["_main"](argc, argv, 0);
 
     // if we're not running an evented main loop, it's time to exit
     exit(ret, /* implicit = */ true);
-  }
-  catch(e) {
+  } catch (e) {
     if (e instanceof ExitStatus) {
       // exit() throws this once it's done to make sure execution
       // has been stopped completely
       return;
-    } else if (e == 'SimulateInfiniteLoop') {
+    } else if (e == "SimulateInfiniteLoop") {
       // running an evented main loop, don't immediately exit
-      Module['noExitRuntime'] = true;
+      Module["noExitRuntime"] = true;
       return;
     } else {
-      if (e && typeof e === 'object' && e.stack) Module.printErr('exception thrown: ' + [e, e.stack]);
+      if (e && typeof e === "object" && e.stack)
+        Module.printErr("exception thrown: " + [e, e.stack]);
       throw e;
     }
   } finally {
     calledMain = true;
   }
-}
-
-
-
+};
 
 function run(args) {
-  args = args || Module['arguments'];
+  args = args || Module["arguments"];
 
   if (preloadStartTime === null) preloadStartTime = Date.now();
 
@@ -2230,15 +2519,14 @@ function run(args) {
     return;
   }
 
-
   preRun();
 
   if (runDependencies > 0) return; // a preRun added a dependency, run will be called later
-  if (Module['calledRun']) return; // run may have just been called through dependencies being fulfilled just in this very frame
+  if (Module["calledRun"]) return; // run may have just been called through dependencies being fulfilled just in this very frame
 
   function doRun() {
-    if (Module['calledRun']) return; // run may have just been called while the async setStatus time below was happening
-    Module['calledRun'] = true;
+    if (Module["calledRun"]) return; // run may have just been called while the async setStatus time below was happening
+    Module["calledRun"] = true;
 
     if (ABORT) return;
 
@@ -2246,19 +2534,18 @@ function run(args) {
 
     preMain();
 
+    if (Module["onRuntimeInitialized"]) Module["onRuntimeInitialized"]();
 
-    if (Module['onRuntimeInitialized']) Module['onRuntimeInitialized']();
-
-    if (Module['_main'] && shouldRunNow) Module['callMain'](args);
+    if (Module["_main"] && shouldRunNow) Module["callMain"](args);
 
     postRun();
   }
 
-  if (Module['setStatus']) {
-    Module['setStatus']('Running...');
-    setTimeout(function() {
-      setTimeout(function() {
-        Module['setStatus']('');
+  if (Module["setStatus"]) {
+    Module["setStatus"]("Running...");
+    setTimeout(function () {
+      setTimeout(function () {
+        Module["setStatus"]("");
       }, 1);
       doRun();
     }, 1);
@@ -2266,34 +2553,33 @@ function run(args) {
     doRun();
   }
 }
-Module['run'] = Module.run = run;
+Module["run"] = Module.run = run;
 
 function exit(status, implicit) {
-  if (implicit && Module['noExitRuntime']) {
+  if (implicit && Module["noExitRuntime"]) {
     return;
   }
 
-  if (Module['noExitRuntime']) {
+  if (Module["noExitRuntime"]) {
   } else {
-
     ABORT = true;
     EXITSTATUS = status;
     STACKTOP = initialStackTop;
 
     exitRuntime();
 
-    if (Module['onExit']) Module['onExit'](status);
+    if (Module["onExit"]) Module["onExit"](status);
   }
 
   if (ENVIRONMENT_IS_NODE) {
-    process['exit'](status);
-  } else if (ENVIRONMENT_IS_SHELL && typeof quit === 'function') {
+    process["exit"](status);
+  } else if (ENVIRONMENT_IS_SHELL && typeof quit === "function") {
     quit(status);
   }
   // if we reach here, we must throw an exception to halt the current execution
   throw new ExitStatus(status);
 }
-Module['exit'] = Module.exit = exit;
+Module["exit"] = Module.exit = exit;
 
 var abortDecorators = [];
 
@@ -2301,51 +2587,45 @@ function abort(what) {
   if (what !== undefined) {
     Module.print(what);
     Module.printErr(what);
-    what = JSON.stringify(what)
+    what = JSON.stringify(what);
   } else {
-    what = '';
+    what = "";
   }
 
   ABORT = true;
   EXITSTATUS = 1;
 
-  var extra = '\nIf this abort() is unexpected, build with -s ASSERTIONS=1 which can give more information.';
+  var extra =
+    "\nIf this abort() is unexpected, build with -s ASSERTIONS=1 which can give more information.";
 
-  var output = 'abort(' + what + ') at ' + stackTrace() + extra;
+  var output = "abort(" + what + ") at " + stackTrace() + extra;
   if (abortDecorators) {
-    abortDecorators.forEach(function(decorator) {
+    abortDecorators.forEach(function (decorator) {
       output = decorator(output, what);
     });
   }
   throw output;
 }
-Module['abort'] = Module.abort = abort;
+Module["abort"] = Module.abort = abort;
 
 // {{PRE_RUN_ADDITIONS}}
 
-if (Module['preInit']) {
-  if (typeof Module['preInit'] == 'function') Module['preInit'] = [Module['preInit']];
-  while (Module['preInit'].length > 0) {
-    Module['preInit'].pop()();
+if (Module["preInit"]) {
+  if (typeof Module["preInit"] == "function")
+    Module["preInit"] = [Module["preInit"]];
+  while (Module["preInit"].length > 0) {
+    Module["preInit"].pop()();
   }
 }
 
 // shouldRunNow refers to calling main(), not run().
 var shouldRunNow = true;
-if (Module['noInitialRun']) {
+if (Module["noInitialRun"]) {
   shouldRunNow = false;
 }
-
 
 run();
 
 // {{POST_RUN_ADDITIONS}}
 
-
-
-
-
 // {{MODULE_ADDITIONS}}
-
-
-

--- a/wasm-sobel/change.wast
+++ b/wasm-sobel/change.wast
@@ -25,7 +25,7 @@
   (import "env" "___unlock" (func $___unlock (param i32)))
   (import "env" "___syscall146" (func $___syscall146 (param i32 i32) (result i32)))
   (import "env" "memory" (memory $0 256 256))
-  (import "env" "table" (table 8 8 anyfunc))
+  (import "env" "table" (table 8 8 funcref))
   (import "env" "memoryBase" (global $memoryBase i32))
   (import "env" "tableBase" (global $tableBase i32))
   (global $DYNAMICTOP_PTR (mut i32) (global.get $DYNAMICTOP_PTR$asm2wasm$import))


### PR DESCRIPTION
`anyfunc` still works but is considered legacy at this point; `funcref` is the up-to-date value type to use. To coincide with https://github.com/mdn/content/pull/45501, this PR changes instances of `anyfunc` in this repo to `funcref`.